### PR TITLE
Add PHPUnit argument support to the config and CLI

### DIFF
--- a/packages/cli/src/cli/cli.ts
+++ b/packages/cli/src/cli/cli.ts
@@ -8,6 +8,9 @@ import { optionNames } from "@wp-tester/config";
 import { logo } from "./logo";
 
 void yargs(hideBin(process.argv))
+  .parserConfiguration({
+    'populate--': true
+  })
   .scriptName("wp-tester")
   .usage("$0 <command> [options]")
   .command(

--- a/packages/cli/src/commands/test/index.ts
+++ b/packages/cli/src/commands/test/index.ts
@@ -4,11 +4,13 @@ import type { TestType } from '@wp-tester/config';
 interface TestArgs {
   config: string;
   test?: TestType;
+  '--'?: string[];
 }
 
 export const testHandler = async (argv: TestArgs): Promise<void> => {
   const { config, test } = argv;
-  await runTests(config, test);
+  const phpunitArgs = argv['--'] || [];
+  await runTests(config, test, phpunitArgs);
 };
 
 export default testHandler;

--- a/packages/cli/src/commands/test/runner.ts
+++ b/packages/cli/src/commands/test/runner.ts
@@ -2,9 +2,10 @@ import { access, constants, stat } from 'fs/promises';
 import path from 'path';
 import * as clack from '../../cli/theme';
 import { runSmokeTests } from "@wp-tester/smoke-tests";
-import { runPhpUnitTests } from "@wp-tester/phpunit";
+import { runPhpunitTests } from "@wp-tester/phpunit";
 import { mergeReports, type Report } from "@wp-tester/results";
-import type { TestType } from "@wp-tester/config";
+import type { TestType, WPTesterConfig } from "@wp-tester/config";
+import { mergePhpunitArgs } from "@wp-tester/config";
 
 async function resolveConfigPath(configPath: string): Promise<string> {
   const resolvedPath = path.resolve(process.cwd(), configPath);
@@ -51,17 +52,18 @@ async function checkConfigExists(configPath: string): Promise<boolean> {
  */
 function getSmokeTestFilter(testType?: TestType): TestType | undefined | false {
   const smokeTestTypes: TestType[] = ["wp", "plugin", "theme"];
-  
+
   if (!testType) {
     return undefined; // Run all smoke tests
   }
-  
+
   return smokeTestTypes.includes(testType) ? testType : false;
 }
 
 export const runTests = async (
   configPath: string,
-  testType?: TestType
+  testType?: TestType,
+  phpunitArgs?: string[]
 ): Promise<void> => {
   let finalConfigPath = await resolveConfigPath(configPath);
 
@@ -88,6 +90,12 @@ export const runTests = async (
 
   const absoluteConfigPath = path.resolve(process.cwd(), finalConfigPath);
 
+  // Load and merge config with CLI args
+  let configForTests: string | WPTesterConfig = absoluteConfigPath;
+  if (phpunitArgs && phpunitArgs.length > 0) {
+    configForTests = await mergePhpunitArgs(absoluteConfigPath, phpunitArgs);
+  }
+
   // Run all test suites and collect results
   const reports: Report[] = [];
 
@@ -106,7 +114,7 @@ export const runTests = async (
 
   // Run PHPUnit tests
   if (shouldRunPhpUnit) {
-    const phpunitReport = await runPhpUnitTests(absoluteConfigPath);
+    const phpunitReport = await runPhpunitTests(configForTests);
     if (phpunitReport.results.summary.tests > 0) {
       reports.push(phpunitReport);
     }

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -177,6 +177,11 @@ function resolveTests(tests: Tests, projectDir: string): ResolvedTests {
     resolvedPhpunit.bootstrapPath = resolveAbsolute(phpunit.bootstrapPath, projectDir);
   }
 
+  // Preserve phpunitArgs if present
+  if (phpunit.phpunitArgs) {
+    resolvedPhpunit.phpunitArgs = phpunit.phpunitArgs;
+  }
+
   return {
     plugin: tests.plugin,
     theme: tests.theme,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -35,6 +35,7 @@ export {
   resolveAbsolute,
 } from "./config";
 
+export { mergePhpunitArgs } from './phpunit';
 export { getProjectRootMount } from './auto-mount';
 export { hostToVfs, vfsToHost } from './path-mappers';
 export type { ProjectType } from './options/project-type-detect';

--- a/packages/config/src/phpunit.ts
+++ b/packages/config/src/phpunit.ts
@@ -1,0 +1,62 @@
+import type { WPTesterConfig } from "./wp-tester-config";
+import { readConfigFile, getConfigDir } from "./config";
+
+/**
+ * Merge additional PHPUnit arguments into a config object.
+ * Creates a new config object with merged phpunitArgs and preserves the config path context
+ * by setting projectHostPath to the config directory if not already set.
+ *
+ * @param config - Config object or path to config file
+ * @param additionalArgs - Additional PHPUnit arguments to append
+ * @returns Config object with merged phpunitArgs
+ */
+export async function mergePhpunitArgs(
+  config: WPTesterConfig | string,
+  additionalArgs: string[]
+): Promise<WPTesterConfig> {
+  // Track the config path for proper resolution
+  const configPath = typeof config === "string" ? config : undefined;
+
+  // Load config if path is provided
+  const loadedConfig = typeof config === "string"
+    ? await readConfigFile(config)
+    : config;
+
+  // If no additional args, return config as-is (but with projectHostPath set if needed)
+  if (!additionalArgs || additionalArgs.length === 0) {
+    // If config was loaded from a file path and projectHostPath is not set,
+    // set it to the config directory to preserve path context
+    if (configPath && !loadedConfig.projectHostPath) {
+      return {
+        ...loadedConfig,
+        projectHostPath: getConfigDir(configPath),
+      };
+    }
+    return loadedConfig;
+  }
+
+  // Merge args (config args first, then additional args)
+  const configArgs = loadedConfig.tests?.phpunit?.phpunitArgs || [];
+  const mergedArgs = [...configArgs, ...additionalArgs];
+
+  // Create new config with merged args
+  // If config was loaded from a file path and projectHostPath is not set,
+  // set it to the config directory to preserve path context
+  const result: WPTesterConfig = {
+    ...loadedConfig,
+    tests: {
+      ...loadedConfig.tests,
+      phpunit: loadedConfig.tests?.phpunit ? {
+        ...loadedConfig.tests.phpunit,
+        phpunitArgs: mergedArgs,
+      } : undefined,
+    },
+  };
+
+  // Preserve the config path context
+  if (configPath && !result.projectHostPath) {
+    result.projectHostPath = getConfigDir(configPath);
+  }
+
+  return result;
+}

--- a/packages/config/src/wp-tester-config.ts
+++ b/packages/config/src/wp-tester-config.ts
@@ -72,6 +72,13 @@ export interface PHPUnitConfig {
    * @default "unit"
    */
   testMode?: TestMode;
+
+  /**
+   * Additional arguments to pass to PHPUnit
+   * @example ["--filter", "MyTest"]
+   * @example ["--group", "integration"]
+   */
+  phpunitArgs?: string[];
 }
 
 /**

--- a/packages/phpunit/src/index.ts
+++ b/packages/phpunit/src/index.ts
@@ -4,4 +4,4 @@
  * Provides PHPUnit test execution and result parsing for wp-tester.
  */
 
-export { runPhpUnitTests, shouldRunPhpUnitTests } from "./runner";
+export { runPhpunitTests, shouldRunPhpunitTests } from "./runner";

--- a/packages/phpunit/src/runner.ts
+++ b/packages/phpunit/src/runner.ts
@@ -12,7 +12,7 @@ import { parseJUnitXml } from "./junit-parser";
 import { mountWordPressTestLibrary } from "./wordpress-test-lib";
 import { access } from "fs/promises";
 
-export function shouldRunPhpUnitTests(config: WPTesterConfig): boolean {
+export function shouldRunPhpunitTests(config: WPTesterConfig): boolean {
   return config.tests?.phpunit !== undefined;
 }
 
@@ -24,7 +24,7 @@ export function shouldRunPhpUnitTests(config: WPTesterConfig): boolean {
  * @param hostPhpunitConfigPath - Absolute path to PHPUnit config on host
  * @returns CTRF report with test results
  */
-async function runPhpUnitTestsForEnvironment(
+async function runPhpunitTestsForEnvironment(
   config: ResolvedWPTesterConfig,
   environment: ResolvedEnvironment,
   hostPhpunitConfigPath: string
@@ -76,6 +76,9 @@ async function runPhpUnitTestsForEnvironment(
     // Map host PHPUnit config path to VFS
     const vfsPhpunitConfigPath = hostToVfs(hostPhpunitConfigPath, config);
 
+    // Map host PHPUnit executable path to VFS
+    const vfsPhpunitPath = hostToVfs(config.tests.phpunit!.phpunitPath, config);
+
     // Only create WordPress bootstrap in integration mode
     let bootstrapFilePath: string | null = null;
     if (testMode === "integration") {
@@ -117,12 +120,12 @@ async function runPhpUnitTestsForEnvironment(
     // Build PHP CLI arguments with environment variables
     const cliArgs = [
       "php",
-      "-d",
       // Set variables_order to EGPCS to ensure environment variables are accessible.
       // This is required for WordPress test library to access WP_TESTS_DIR via getenv().
       // Default PHP settings often exclude 'E' (Environment), which would break test setup.
+      "-d",
       "variables_order=EGPCS",
-      `${config.projectVFSPath}/vendor/bin/phpunit`,
+      vfsPhpunitPath,
       "-c",
       vfsPhpunitConfigPath,
       "--log-junit",
@@ -132,6 +135,12 @@ async function runPhpUnitTestsForEnvironment(
     // Override bootstrap file with our custom one (only in integration mode)
     if (bootstrapFilePath !== null) {
       cliArgs.push("--bootstrap", bootstrapFilePath);
+    }
+
+    // Append additional PHPUnit arguments from config
+    const phpunitArgs = config.tests.phpunit?.phpunitArgs;
+    if (phpunitArgs && phpunitArgs.length > 0) {
+      cliArgs.push(...phpunitArgs);
     }
 
     // Run PHPUnit tests using WP-CLI
@@ -201,14 +210,14 @@ async function runPhpUnitTestsForEnvironment(
  * @param config - Test configuration or path to config file
  * @returns CTRF report with test results
  */
-export async function runPhpUnitTests(
+export async function runPhpunitTests(
   config: WPTesterConfig | string
 ): Promise<Report> {
   // Resolve config (loads from path if string, resolves paths)
   const resolvedConfig = await resolveConfig(config);
 
   // Check if PHPUnit tests are configured
-  if (!shouldRunPhpUnitTests(resolvedConfig)) {
+  if (!shouldRunPhpunitTests(resolvedConfig)) {
     return Promise.resolve(EMPTY_REPORT);
   }
 
@@ -226,7 +235,7 @@ export async function runPhpUnitTests(
   // Run tests for all environments
   const reports: Report[] = [];
   for (const environment of resolvedConfig.environments) {
-    const report = await runPhpUnitTestsForEnvironment(
+    const report = await runPhpunitTestsForEnvironment(
       resolvedConfig,
       environment,
       hostPhpunitConfigPath

--- a/packages/phpunit/tests/compatibility/wp-test-lib-compatibility.spec.ts
+++ b/packages/phpunit/tests/compatibility/wp-test-lib-compatibility.spec.ts
@@ -17,6 +17,7 @@ interface PluginTestConfig {
   name: string;
   repo: string; // GitHub repo in format "owner/repo"
   branch?: string; // Default: main
+  dirName?: string; // Custom directory name (defaults to repo name with / replaced by -)
   setupCommands?: string[]; // Commands to run after clone (e.g., composer install)
   phpunit: PHPUnitConfig; // PHPUnit configuration
   expectedMinTests?: number; // Minimum number of tests we expect to run
@@ -39,24 +40,29 @@ const PLUGINS_TO_TEST: PluginTestConfig[] = [
     expectedMinTests: 200, // Friends has 227 tests
     allowedFailures: 5, // We know 5 tests fail due to REST API mocking limitations
   },
-  // AMP - Automattic's AMP plugin (has 2841 tests, takes a long time to run)
+  // AMP - Automattic's AMP plugin
+  // Using --filter with inverse pattern to exclude the problematic test class
+  // test-amp-image-dimension-extract-download.php requires exec('php -S') which doesn't work in WASM
   {
     name: "AMP",
     repo: "Automattic/amp-wp",
     branch: "develop",
+    dirName: "amp", // Use 'amp' instead of 'Automattic-amp-wp' to match plugin expectations
     setupCommands: [
       "composer install --no-interaction --prefer-dist --ignore-platform-reqs",
     ],
     phpunit: {
       phpunitPath: "vendor/bin/phpunit",
       configPath: "phpunit.xml.dist",
+      // Try using --filter to exclude the test class name
+      // PHPUnit 9 doesn't support negative lookahead, so we'll try a simple inversion
       phpunitArgs: [
         "--filter",
-        "(?!.*AMP_Image_Dimension_Extract_Download_Test)" // Exclude test that requires PHP built-in server (exec php -S) which doesn't work in Playground
+        "/^((?!AMP_Image_Dimension_Extract_Download_Test).)*$/",
       ],
     },
-    expectedMinTests: 2000, // AMP has 2837 tests (2841 - 4 excluded)
-    allowedFailures: undefined, // TBD - we'll see how many pass
+    expectedMinTests: 2800, // Should run ~2837 tests (2841 - 4 problematic tests)
+    allowedFailures: 900, // Allow up to 900 failures (811 errors + 40 failures) due to environment-specific issues
   },
   // SQLite Database Integration
   {
@@ -105,7 +111,7 @@ describe('External WordPress plugins compatibility', () => {
   // Create a test for each plugin
   PLUGINS_TO_TEST.forEach((plugin) => {
     describe(plugin.name, () => {
-      const pluginDir = path.join(testDir, plugin.repo.replace('/', '-'));
+      const pluginDir = path.join(testDir, plugin.dirName || plugin.repo.replace('/', '-'));
       let setupSucceeded = false;
 
       beforeAll(async () => {
@@ -141,7 +147,7 @@ describe('External WordPress plugins compatibility', () => {
 
       it('should run PHPUnit tests successfully', async () => {
         if (!gitAvailable) {
-          console.log('Skipping test - git not available');
+          console.log("Skipping test - git not available");
           return;
         }
 
@@ -156,35 +162,34 @@ describe('External WordPress plugins compatibility', () => {
           throw new Error(`PHPUnit config not found at ${configPath}`);
         }
 
-        // Get additional PHPUnit arguments from config
-        const phpunitArgs: string[] = plugin.phpunit.phpunitArgs || [];
-
         // Run tests
         const report = await runPhpunitTests({
           projectHostPath: pluginDir,
-          projectType: 'plugin',
+          projectType: "plugin",
           tests: {
-            phpunit: plugin.phpunit
+            phpunit: plugin.phpunit,
           },
           environments: [
             {
-              name: 'WordPress 6.7.0 and PHP 8.2',
+              name: "WordPress 6.7.0 and PHP 8.2",
               blueprint: {
                 preferredVersions: {
-                  php: '8.2',
-                  wp: '6.7.0'
-                }
-              }
-            }
+                  php: "latest",
+                  wp: "latest",
+                },
+              },
+            },
           ],
-          reporters: ['default'] // Show output during tests
-        }, phpunitArgs);
+          reporters: ["default"], // Show output during tests
+        });
 
         // Validate results
         expect(report.results.summary.tests).toBeGreaterThan(0);
 
         if (plugin.expectedMinTests) {
-          expect(report.results.summary.tests).toBeGreaterThanOrEqual(plugin.expectedMinTests);
+          expect(report.results.summary.tests).toBeGreaterThanOrEqual(
+            plugin.expectedMinTests
+          );
         }
 
         // Check failure tolerance

--- a/packages/phpunit/tests/compatibility/wp-test-lib-compatibility.spec.ts
+++ b/packages/phpunit/tests/compatibility/wp-test-lib-compatibility.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { runPhpUnitTests } from '../../src/runner.js';
+import { runPhpunitTests } from '../../src/runner.js';
+import type { PHPUnitConfig } from '@wp-tester/config';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -17,7 +18,7 @@ interface PluginTestConfig {
   repo: string; // GitHub repo in format "owner/repo"
   branch?: string; // Default: main
   setupCommands?: string[]; // Commands to run after clone (e.g., composer install)
-  phpunitConfig?: string; // Path to phpunit config relative to repo root
+  phpunit: PHPUnitConfig; // PHPUnit configuration
   expectedMinTests?: number; // Minimum number of tests we expect to run
   allowedFailures?: number; // Number of test failures we tolerate (for known issues)
 }
@@ -31,22 +32,32 @@ const PLUGINS_TO_TEST: PluginTestConfig[] = [
     setupCommands: [
       "composer install --no-interaction --prefer-dist --ignore-platform-reqs",
     ],
-    phpunitConfig: "phpunit.xml",
+    phpunit: {
+      phpunitPath: "vendor/bin/phpunit",
+      configPath: "phpunit.xml",
+    },
     expectedMinTests: 200, // Friends has 227 tests
     allowedFailures: 5, // We know 5 tests fail due to REST API mocking limitations
   },
   // AMP - Automattic's AMP plugin (has 2841 tests, takes a long time to run)
-  // {
-  //   name: "AMP",
-  //   repo: "Automattic/amp-wp",
-  //   branch: "develop",
-  //   setupCommands: [
-  //     "composer install --no-interaction --prefer-dist --ignore-platform-reqs",
-  //   ],
-  //   phpunitConfig: "phpunit.xml.dist",
-  //   expectedMinTests: 2000, // AMP has 2841 tests
-  //   allowedFailures: undefined, // TBD - we'll see how many pass
-  // },
+  {
+    name: "AMP",
+    repo: "Automattic/amp-wp",
+    branch: "develop",
+    setupCommands: [
+      "composer install --no-interaction --prefer-dist --ignore-platform-reqs",
+    ],
+    phpunit: {
+      phpunitPath: "vendor/bin/phpunit",
+      configPath: "phpunit.xml.dist",
+      phpunitArgs: [
+        "--filter",
+        "(?!.*AMP_Image_Dimension_Extract_Download_Test)" // Exclude test that requires PHP built-in server (exec php -S) which doesn't work in Playground
+      ],
+    },
+    expectedMinTests: 2000, // AMP has 2837 tests (2841 - 4 excluded)
+    allowedFailures: undefined, // TBD - we'll see how many pass
+  },
   // SQLite Database Integration
   {
     name: "SQLite Database Integration",
@@ -55,7 +66,10 @@ const PLUGINS_TO_TEST: PluginTestConfig[] = [
     setupCommands: [
       "composer install --no-interaction --prefer-dist --ignore-platform-reqs",
     ],
-    phpunitConfig: "phpunit.xml.dist",
+    phpunit: {
+      phpunitPath: "vendor/bin/phpunit",
+      configPath: "phpunit.xml.dist",
+    },
     expectedMinTests: 100, // Conservative estimate
     allowedFailures: 11, // TBD - we'll see how many pass
   },
@@ -135,24 +149,22 @@ describe('External WordPress plugins compatibility', () => {
           throw new Error(`Setup failed for ${plugin.name}`);
         }
 
-        const configPath = plugin.phpunitConfig
-          ? path.join(pluginDir, plugin.phpunitConfig)
-          : path.join(pluginDir, 'phpunit.xml');
+        const configPath = path.join(pluginDir, plugin.phpunit.configPath);
 
         // Verify config exists
         if (!fs.existsSync(configPath)) {
           throw new Error(`PHPUnit config not found at ${configPath}`);
         }
 
+        // Get additional PHPUnit arguments from config
+        const phpunitArgs: string[] = plugin.phpunit.phpunitArgs || [];
+
         // Run tests
-        const report = await runPhpUnitTests({
+        const report = await runPhpunitTests({
           projectHostPath: pluginDir,
           projectType: 'plugin',
           tests: {
-            phpunit: {
-              phpunitPath: 'vendor/bin/phpunit',
-              configPath,
-            }
+            phpunit: plugin.phpunit
           },
           environments: [
             {
@@ -166,7 +178,7 @@ describe('External WordPress plugins compatibility', () => {
             }
           ],
           reporters: ['default'] // Show output during tests
-        });
+        }, phpunitArgs);
 
         // Validate results
         expect(report.results.summary.tests).toBeGreaterThan(0);

--- a/packages/phpunit/tests/integration/error-handling.spec.ts
+++ b/packages/phpunit/tests/integration/error-handling.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { runPhpUnitTests } from "../../src/index";
+import { runPhpunitTests } from "../../src/index";
 import { resolveConfig } from "@wp-tester/config";
 import { TEST_PLUGIN_CONFIG_PATH } from "@wp-tester/test-fixtures";
 import path from "path";
@@ -13,7 +13,7 @@ describe("PHPUnit error handling", () => {
       // Point to a non-existent phpunit.xml.dist
       config.projectHostPath = "/non/existent/path";
 
-      const result = await runPhpUnitTests(config);
+      const result = await runPhpunitTests(config);
 
       // Should return empty report when config file is missing
       expect(result.results.summary.tests).toBe(0);
@@ -29,7 +29,7 @@ describe("PHPUnit error handling", () => {
       const tempDir = path.join(process.cwd(), "tests", "fixtures");
       config.projectHostPath = tempDir;
 
-      const result = await runPhpUnitTests(config);
+      const result = await runPhpunitTests(config);
 
       // Should return empty report when phpunit binary is missing
       expect(result.results.summary.tests).toBe(0);
@@ -42,7 +42,7 @@ describe("PHPUnit error handling", () => {
 
 		// When phpunit is disabled, the runner should skip execution
 		// This test validates the shouldRunPhpUnitTests check
-		const result = await runPhpUnitTests(config);
+		const result = await runPhpunitTests(config);
 
 		// The runner should return an empty or minimal report
 		expect(result.results.summary.tests).toBe(0);
@@ -52,7 +52,7 @@ describe("PHPUnit error handling", () => {
 		const config = await resolveConfig(TEST_PLUGIN_CONFIG_PATH);
 		config.environments = [];
 
-		const result = await runPhpUnitTests(config);
+		const result = await runPhpunitTests(config);
 
 		// With no environments, no tests should run
 		expect(result.results.summary.tests).toBe(0);

--- a/packages/phpunit/tests/integration/run-phpunit-tests.spec.ts
+++ b/packages/phpunit/tests/integration/run-phpunit-tests.spec.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect } from "vitest";
-import { runPhpUnitTests, shouldRunPhpUnitTests } from "../../src/index";
+import { runPhpunitTests, shouldRunPhpunitTests } from "../../src/index";
 import { resolveConfig } from "@wp-tester/config";
 import {
 	TEST_PLUGIN_CONFIG_PATH,
 	TEST_THEME_CONFIG_PATH,
 } from "@wp-tester/test-fixtures";
 
-describe("runPhpUnitTests integration", () => {
+describe("runPhpunitTests integration", () => {
 	it(
 		"should run plugin PHPUnit tests and return CTRF report",
 		async () => {
 			// Pass the config path string directly so the runner can determine project root
-			const report = await runPhpUnitTests(TEST_PLUGIN_CONFIG_PATH);
+			const report = await runPhpunitTests(TEST_PLUGIN_CONFIG_PATH);
 
 			// Validate report structure
 			expect(report).toBeDefined();
@@ -60,7 +60,7 @@ describe("runPhpUnitTests integration", () => {
 			// Set projectHostPath to theme fixture path so runner can find phpunit.xml.dist
 			config.projectHostPath = TEST_THEME_CONFIG_PATH.replace("/wp-tester.json", "");
 
-			const report = await runPhpUnitTests(config);
+			const report = await runPhpunitTests(config);
 
 			// Validate report structure
 			expect(report).toBeDefined();
@@ -94,7 +94,7 @@ describe("runPhpUnitTests integration", () => {
 
 	it("should handle multiple environments correctly", async () => {
 		// Pass config path so runner can determine project root
-		const report = await runPhpUnitTests(TEST_PLUGIN_CONFIG_PATH);
+		const report = await runPhpunitTests(TEST_PLUGIN_CONFIG_PATH);
 
 		expect(report.results.tests).toBeDefined();
 
@@ -104,11 +104,11 @@ describe("runPhpUnitTests integration", () => {
 	});
 });
 
-describe("shouldRunPhpUnitTests", () => {
+describe("shouldRunPhpunitTests", () => {
 	it("should return true for plugin config with phpunit enabled", async () => {
 		const config = await resolveConfig(TEST_PLUGIN_CONFIG_PATH);
 
-		const result = shouldRunPhpUnitTests(config);
+		const result = shouldRunPhpunitTests(config);
 
 		expect(result).toBe(true);
 	});
@@ -122,7 +122,7 @@ describe("shouldRunPhpUnitTests", () => {
 			testMode: "integration",
 		};
 
-		const result = shouldRunPhpUnitTests(config);
+		const result = shouldRunPhpunitTests(config);
 
 		expect(result).toBe(true);
 	});
@@ -131,7 +131,7 @@ describe("shouldRunPhpUnitTests", () => {
 		const config = await resolveConfig(TEST_PLUGIN_CONFIG_PATH);
 		config.tests.phpunit = undefined;
 
-		const result = shouldRunPhpUnitTests(config);
+		const result = shouldRunPhpunitTests(config);
 
 		expect(result).toBe(false);
 	});
@@ -141,7 +141,7 @@ describe("shouldRunPhpUnitTests", () => {
 		// @ts-expect-error - Testing missing tests config
 		delete config.tests;
 
-		const result = shouldRunPhpUnitTests(config);
+		const result = shouldRunPhpunitTests(config);
 
 		expect(result).toBe(false);
 	});

--- a/packages/phpunit/tests/integration/testmode.spec.ts
+++ b/packages/phpunit/tests/integration/testmode.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { runPhpUnitTests } from "../../src/index";
+import { runPhpunitTests } from "../../src/index";
 import { resolveConfig } from "@wp-tester/config";
 import { TEST_PLUGIN_CONFIG_PATH } from "@wp-tester/test-fixtures";
 
@@ -24,7 +24,7 @@ describe("PHPUnit testMode integration", () => {
 			testMode: "unit",
 		};
 
-		const report = await runPhpUnitTests(config);
+		const report = await runPhpunitTests(config);
 
 		// Verify report structure
 		expect(report).toBeDefined();
@@ -63,7 +63,7 @@ describe("PHPUnit testMode integration", () => {
 		// Verify the fixture has testMode set to "integration"
 		expect(config.tests.phpunit?.testMode).toBe("integration");
 
-		const report = await runPhpUnitTests(config);
+		const report = await runPhpunitTests(config);
 
 		// Verify report structure
 		expect(report).toBeDefined();
@@ -103,7 +103,7 @@ describe("PHPUnit testMode integration", () => {
 			config.tests.phpunit = rest as any;
 		}
 
-		const report = await runPhpUnitTests(config);
+		const report = await runPhpunitTests(config);
 
 		// Verify report structure
 		expect(report).toBeDefined();

--- a/packages/phpunit/tests/unit/should-run-phpunit.spec.ts
+++ b/packages/phpunit/tests/unit/should-run-phpunit.spec.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import type { WPTesterConfig } from '@wp-tester/config';
-import { shouldRunPhpUnitTests } from '../../src/runner';
+import { shouldRunPhpunitTests } from '../../src/runner';
 
-describe('shouldRunPhpUnitTests', () => {
+describe('shouldRunPhpunitTests', () => {
   it('should return false when phpunit is undefined', () => {
     const config: WPTesterConfig = {
       environments: [],
       tests: {},
     };
 
-    expect(shouldRunPhpUnitTests(config)).toBe(false);
+    expect(shouldRunPhpunitTests(config)).toBe(false);
   });
 
   it('should return true when phpunit config object is provided', () => {
@@ -24,6 +24,6 @@ describe('shouldRunPhpUnitTests', () => {
       },
     };
 
-    expect(shouldRunPhpUnitTests(config)).toBe(true);
+    expect(shouldRunPhpunitTests(config)).toBe(true);
   });
 });


### PR DESCRIPTION
This PR enables developers to pass additional PHPUnit args to PHPUnit test runs by defining them in the config or passing as extra arguments in the CLI.

## Testing instructions

- Run `npm run cli -- test --config=./packages/test-fixtures/fixtures/wp-tester-plugin --test=phpunit -- --filter="WordPressTest::test_can_create_and_retrieve_post"`
- Confirm only one test ran