### PR TITLE
Add --watch support to the test command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -179,6 +179,9 @@ wp-tester test --test phpunit
 # Use custom config file
 wp-tester test --config custom-config.json
 
+# Use config from a directory (looks for wp-tester.json in the directory)
+wp-tester test --config /path/to/project
+
 # Watch mode - re-run tests on file changes
 wp-tester test --watch
 ```
@@ -201,9 +204,11 @@ Configure which files to watch in `wp-tester.json`:
 
 ```json
 {
-  "watch": {
-    "include": ["src/**/*.php", "tests/**/*.php"],
-    "exclude": ["vendor/**", "node_modules/**"]
+  "tests": {
+    "watch": {
+      "include": ["src/**/*.php", "tests/**/*.php"],
+      "exclude": ["vendor/**", "node_modules/**"]
+    }
   }
 }
 ```
@@ -218,8 +223,11 @@ Validate your configuration file:
 # Validate default config
 wp-tester config validate
 
-# Validate custom config
+# Validate custom config file
 wp-tester config validate --config custom-config.json
+
+# Validate config in a directory (looks for wp-tester.json)
+wp-tester config validate --config /path/to/project
 ```
 
 ### `config <option>`

--- a/docs/README.md
+++ b/docs/README.md
@@ -178,7 +178,37 @@ wp-tester test --test phpunit
 
 # Use custom config file
 wp-tester test --config custom-config.json
+
+# Watch mode - re-run tests on file changes
+wp-tester test --watch
 ```
+
+#### Watch Mode
+
+Use `--watch` (or `-w`) to automatically re-run tests when files change:
+
+```bash
+wp-tester test --watch
+```
+
+In watch mode:
+- Tests run immediately on startup
+- File changes trigger automatic re-runs (with 300ms debounce)
+- Press **Enter** to manually re-run tests
+- Press **q** to quit
+
+Configure which files to watch in `wp-tester.json`:
+
+```json
+{
+  "watch": {
+    "include": ["src/**/*.php", "tests/**/*.php"],
+    "exclude": ["vendor/**", "node_modules/**"]
+  }
+}
+```
+
+See [Watch Configuration](configuration.md#watch) for details.
 
 ### `config validate`
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -11,6 +11,7 @@
     - [PHPUnit Test Modes](configuration.md#phpunit-test-modes)
     - [WordPress Tests Library](configuration.md#wordpress-tests-library-support)
   - [Reporters](configuration.md#reporters)
+  - [Watch Mode](configuration.md#watch)
   - [Complete Examples](configuration.md#complete-examples)
 
 - Test Types

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,9 @@ This command validates your `wp-tester.json` file against the JSON schema to ens
 
 ### Validation Options
 
-- `--config` or `-c`: Specify a custom path to your configuration file (default: `./wp-tester.json`)
+- `--config` or `-c`: Specify a custom path to your configuration file or directory (default: `./wp-tester.json`)
+  - When a directory path is provided, wp-tester will look for `wp-tester.json` within that directory
+  - When a file path is provided, wp-tester will use that specific file
 
 **Examples:**
 
@@ -50,6 +52,9 @@ wp-tester config validate
 
 # Validate a configuration file at a custom location
 wp-tester config validate --config ./configs/prod-config.json
+
+# Validate using a directory path (looks for wp-tester.json in the directory)
+wp-tester config validate --config /path/to/project
 ```
 
 The validation will check for:
@@ -506,15 +511,20 @@ You can use multiple reporters simultaneously:
 }
 ```
 
-### `watch`
+#### `tests.watch`
 
 **Type:** `Object`
 **Required:** No
 **Description:** Configures watch mode behavior when using `wp-tester test --watch`. Controls which files trigger test re-runs.
 
+Watch mode monitors the project directory for file changes. The project directory is determined by:
+- The directory containing `wp-tester.json` if no `projectHostPath` is specified
+- The `projectHostPath` configuration option if specified
+- When using `--config` with a directory path, the directory itself is used as the project directory
+
 **Properties:**
 
-#### `watch.include`
+##### `tests.watch.include`
 
 **Type:** `Array<string>`
 **Required:** No
@@ -523,21 +533,25 @@ You can use multiple reporters simultaneously:
 **Examples:**
 ```json
 {
-  "watch": {
-    "include": ["src/**/*.php", "tests/**/*.php"]
+  "tests": {
+    "watch": {
+      "include": ["src/**/*.php", "tests/**/*.php"]
+    }
   }
 }
 ```
 
 ```json
 {
-  "watch": {
-    "include": ["**/*.php", "**/*.js"]
+  "tests": {
+    "watch": {
+      "include": ["**/*.php", "**/*.js"]
+    }
   }
 }
 ```
 
-#### `watch.exclude`
+##### `tests.watch.exclude`
 
 **Type:** `Array<string>`
 **Required:** No
@@ -547,8 +561,10 @@ You can use multiple reporters simultaneously:
 **Example:**
 ```json
 {
-  "watch": {
-    "exclude": ["vendor/**", "node_modules/**", "*.log", "coverage/**"]
+  "tests": {
+    "watch": {
+      "exclude": ["vendor/**", "node_modules/**", "*.log", "coverage/**"]
+    }
   }
 }
 ```
@@ -557,9 +573,16 @@ You can use multiple reporters simultaneously:
 
 ```json
 {
-  "watch": {
-    "include": ["src/**/*.php", "tests/**/*.php", "includes/**/*.php"],
-    "exclude": ["vendor/**", "node_modules/**", "*.log"]
+  "tests": {
+    "plugin": "my-plugin",
+    "phpunit": {
+      "phpunitPath": "vendor/bin/phpunit",
+      "configPath": "phpunit.xml.dist"
+    },
+    "watch": {
+      "include": ["src/**/*.php", "tests/**/*.php", "includes/**/*.php"],
+      "exclude": ["vendor/**", "node_modules/**", "*.log"]
+    }
   }
 }
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -506,6 +506,81 @@ You can use multiple reporters simultaneously:
 }
 ```
 
+### `watch`
+
+**Type:** `Object`
+**Required:** No
+**Description:** Configures watch mode behavior when using `wp-tester test --watch`. Controls which files trigger test re-runs.
+
+**Properties:**
+
+#### `watch.include`
+
+**Type:** `Array<string>`
+**Required:** No
+**Description:** Glob patterns for files/directories to watch. If not specified, watches all files in the project directory.
+
+**Examples:**
+```json
+{
+  "watch": {
+    "include": ["src/**/*.php", "tests/**/*.php"]
+  }
+}
+```
+
+```json
+{
+  "watch": {
+    "include": ["**/*.php", "**/*.js"]
+  }
+}
+```
+
+#### `watch.exclude`
+
+**Type:** `Array<string>`
+**Required:** No
+**Default:** `["**/node_modules/**", "**/vendor/**", "**/.git/**"]`
+**Description:** Glob patterns to exclude from watching. These patterns are checked before include patterns.
+
+**Example:**
+```json
+{
+  "watch": {
+    "exclude": ["vendor/**", "node_modules/**", "*.log", "coverage/**"]
+  }
+}
+```
+
+**Complete Example:**
+
+```json
+{
+  "watch": {
+    "include": ["src/**/*.php", "tests/**/*.php", "includes/**/*.php"],
+    "exclude": ["vendor/**", "node_modules/**", "*.log"]
+  }
+}
+```
+
+**Behavior:**
+
+1. If `include` is specified, only files matching those patterns trigger re-runs
+2. Files matching `exclude` patterns are always ignored
+3. If `include` is not specified, all files (except excluded ones) trigger re-runs
+4. Default excludes cover common directories that shouldn't trigger tests (node_modules, vendor, .git)
+
+**Usage:**
+
+```bash
+# Start watch mode
+wp-tester test --watch
+
+# Watch mode with specific test type
+wp-tester test --watch --test phpunit
+```
+
 ## Complete Examples
 
 ### Minimal Configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -2385,6 +2385,13 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/xml2js": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
@@ -10514,6 +10521,7 @@
         "@wp-tester/smoke-tests": "*",
         "ajv": "^8.17.1",
         "picocolors": "^1.1.1",
+        "picomatch": "^4.0.3",
         "yargs": "^18.0.0"
       },
       "bin": {
@@ -10521,6 +10529,7 @@
       },
       "devDependencies": {
         "@types/node": "^24.10.1",
+        "@types/picomatch": "^4.0.2",
         "@types/yargs": "^17.0.35",
         "@wp-playground/blueprints": "3.0.15",
         "@wp-playground/cli": "3.0.15",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,10 +36,12 @@
     "@wp-tester/smoke-tests": "*",
     "ajv": "^8.17.1",
     "picocolors": "^1.1.1",
+    "picomatch": "^4.0.3",
     "yargs": "^18.0.0"
   },
   "devDependencies": {
     "@types/node": "^24.10.1",
+    "@types/picomatch": "^4.0.2",
     "@types/yargs": "^17.0.35",
     "@wp-playground/blueprints": "3.0.15",
     "@wp-playground/cli": "3.0.15",

--- a/packages/cli/src/cli/cli.ts
+++ b/packages/cli/src/cli/cli.ts
@@ -61,6 +61,12 @@ void yargs(hideBin(process.argv))
           describe: "Type of test to run (wp, plugin, theme, or phpunit)",
           type: "string" as const,
           choices: ["wp", "plugin", "theme", "phpunit"] as const,
+        })
+        .option("watch", {
+          alias: "w",
+          describe: "Watch for file changes and re-run tests automatically",
+          type: "boolean" as const,
+          default: false,
         });
     },
     async (argv) => {

--- a/packages/cli/src/commands/config/validate.ts
+++ b/packages/cli/src/commands/config/validate.ts
@@ -2,7 +2,7 @@ import { readFile } from 'fs/promises';
 import path from 'path';
 import Ajv, { type ErrorObject } from "ajv";
 import pc from "picocolors";
-import { getSchemaPath } from "@wp-tester/config";
+import { getSchemaPath, normalizeConfigPath } from "@wp-tester/config";
 import * as clack from "../../cli/theme";
 
 interface ValidationErrorDisplay {
@@ -114,8 +114,8 @@ export function formatValidationError(error: ErrorObject): ValidationErrorDispla
  */
 export async function validateConfig(configPath: string): Promise<boolean> {
   try {
-    // Resolve config path relative to cwd
-    const resolvedConfigPath = path.resolve(process.cwd(), configPath);
+    // Resolve config path relative to cwd and normalize (handles directory paths)
+    const resolvedConfigPath = normalizeConfigPath(path.resolve(process.cwd(), configPath));
 
     const config = JSON.parse(await readFile(resolvedConfigPath, "utf-8")) as unknown;
     // Get schema path from config package

--- a/packages/cli/src/commands/test/index.ts
+++ b/packages/cli/src/commands/test/index.ts
@@ -1,16 +1,30 @@
-import { runTests } from './runner';
+import { runTests, executeTests } from './runner';
+import { runWatchMode } from './watcher';
 import type { TestType } from '@wp-tester/config';
+import path from 'path';
 
 interface TestArgs {
   config: string;
   test?: TestType;
+  watch?: boolean;
   '--'?: string[];
 }
 
 export const testHandler = async (argv: TestArgs): Promise<void> => {
-  const { config, test } = argv;
+  const { config, test, watch } = argv;
   const phpunitArgs = argv['--'] || [];
-  await runTests(config, test, phpunitArgs);
+
+  if (watch) {
+    const absoluteConfigPath = path.resolve(process.cwd(), config);
+    await runWatchMode({
+      configPath: absoluteConfigPath,
+      onRunTests: async () => {
+        await executeTests(absoluteConfigPath, test, phpunitArgs);
+      },
+    });
+  } else {
+    await runTests(config, test, phpunitArgs);
+  }
 };
 
 export default testHandler;

--- a/packages/cli/src/commands/test/runner.ts
+++ b/packages/cli/src/commands/test/runner.ts
@@ -83,12 +83,14 @@ export const executeTests = async (
 
   // Run smoke tests (wp, plugin, theme) - smoke tests package handles whether to run
   const smokeTestFilter = getSmokeTestFilter(testType);
-  const smokeTestReport = await runSmokeTests(
-    absoluteConfigPath,
-    smokeTestFilter
-  );
-  if (smokeTestReport.results.summary.tests > 0) {
-    reports.push(smokeTestReport);
+  if (smokeTestFilter !== false) {
+    const smokeTestReport = await runSmokeTests(
+      absoluteConfigPath,
+      smokeTestFilter
+    );
+    if (smokeTestReport.results.summary.tests > 0) {
+      reports.push(smokeTestReport);
+    }
   }
 
   // Run PHPUnit tests

--- a/packages/cli/src/commands/test/runner.ts
+++ b/packages/cli/src/commands/test/runner.ts
@@ -102,7 +102,7 @@ export const executeTests = async (
   options?: RunTestsOptions
 ): Promise<TestResult> => {
   const { testType, phpunitArgs } = options || {};
-  let finalConfigPath = await resolveConfigPath(configPath);
+  const finalConfigPath = await resolveConfigPath(configPath);
 
   // Validate configuration before running tests
   const isValid = await validateConfig(finalConfigPath);

--- a/packages/cli/src/commands/test/runner.ts
+++ b/packages/cli/src/commands/test/runner.ts
@@ -59,6 +59,77 @@ function getSmokeTestFilter(testType?: TestType): TestType | undefined | false {
   return smokeTestTypes.includes(testType) ? testType : false;
 }
 
+export interface TestResult {
+  success: boolean;
+  hasTests: boolean;
+}
+
+/**
+ * Execute tests and return results without exiting the process.
+ * Used internally and by watch mode.
+ */
+export const executeTests = async (
+  configPath: string,
+  testType?: TestType,
+  phpunitArgs?: string[]
+): Promise<TestResult> => {
+  const absoluteConfigPath = path.resolve(process.cwd(), configPath);
+
+  // Run all test suites and collect results
+  const reports: Report[] = [];
+
+  // Determine which tests to run based on testType parameter
+  const shouldRunPhpUnit = !testType || testType === "phpunit";
+
+  // Run smoke tests (wp, plugin, theme) - smoke tests package handles whether to run
+  const smokeTestFilter = getSmokeTestFilter(testType);
+  const smokeTestReport = await runSmokeTests(
+    absoluteConfigPath,
+    smokeTestFilter
+  );
+  if (smokeTestReport.results.summary.tests > 0) {
+    reports.push(smokeTestReport);
+  }
+
+  // Run PHPUnit tests
+  if (shouldRunPhpUnit) {
+    const phpunitReport = await runPhpunitTests(absoluteConfigPath, phpunitArgs);
+    // Always include report if PHPUnit was configured to run
+    // This ensures bootstrap failures are visible
+    if (phpunitReport.results.summary.tests > 0) {
+      reports.push(phpunitReport);
+    }
+  }
+
+  // No tests were run
+  if (reports.length === 0) {
+    clack.log.error("No tests were run. Check your configuration.");
+    return { success: false, hasTests: false };
+  }
+
+  // Merge results from all test suites
+  const mergedReport = mergeReports(reports);
+
+  // Display unified summary
+  const { summary, tests } = mergedReport.results;
+  const success = summary.failed === 0;
+
+  // Print failed test details
+  const failedTests = tests.filter(test => test.status === 'failed');
+  if (failedTests.length > 0) {
+    for (const test of failedTests) {
+      if (test.trace) {
+        console.error(`\n${test.name}:\n${test.trace}`);
+      }
+    }
+  }
+
+  // Print final combined summary
+  printSummary(summary);
+
+  return { success, hasTests: true };
+};
+
 export const runTests = async (
   configPath: string,
   testType?: TestType,
@@ -87,59 +158,11 @@ export const runTests = async (
     finalConfigPath = newPath;
   }
 
-  const absoluteConfigPath = path.resolve(process.cwd(), finalConfigPath);
+  const result = await executeTests(finalConfigPath, testType, phpunitArgs);
 
-  // Run all test suites and collect results
-  const reports: Report[] = [];
-
-  // Determine which tests to run based on testType parameter
-  const shouldRunPhpUnit = !testType || testType === "phpunit";
-
-  // Run smoke tests (wp, plugin, theme) - smoke tests package handles whether to run
-  const smokeTestFilter = getSmokeTestFilter(testType);
-  const smokeTestReport = await runSmokeTests(
-    absoluteConfigPath,
-    smokeTestFilter
-  );
-  if (smokeTestReport.results.summary.tests > 0) {
-    reports.push(smokeTestReport);
-  }
-
-  // Run PHPUnit tests
-  if (shouldRunPhpUnit) {
-    const phpunitReport = await runPhpunitTests(absoluteConfigPath, phpunitArgs);
-    // Always include report if PHPUnit was configured to run
-    // This ensures bootstrap failures are visible
-    if (phpunitReport.results.summary.tests > 0) {
-      reports.push(phpunitReport);
-    }
-  }
-
-  // Merge all reports
-  if (reports.length === 0) {
-    clack.log.error("No tests were run. Check your configuration.");
+  if (!result.hasTests) {
     process.exit(1);
   }
 
-  // Merge results from all test suites
-  const mergedReport = mergeReports(reports);
-
-  // Display unified summary
-  const { summary, tests } = mergedReport.results;
-  const success = summary.failed === 0;
-
-  // Print failed test details
-  const failedTests = tests.filter(test => test.status === 'failed');
-  if (failedTests.length > 0) {
-    for (const test of failedTests) {
-      if (test.trace) {
-        console.error(`\n${test.name}:\n${test.trace}`);
-      }
-    }
-  }
-
-  // Print final combined summary
-  printSummary(summary);
-
-  process.exit(success ? 0 : 1);
+  process.exit(result.success ? 0 : 1);
 };

--- a/packages/cli/src/commands/test/watcher.ts
+++ b/packages/cli/src/commands/test/watcher.ts
@@ -1,30 +1,11 @@
-import { watch, type FSWatcher, statSync } from 'fs';
-import { join, resolve } from 'path';
+import { watch, type FSWatcher } from 'fs';
 import picomatch from 'picomatch';
 import * as clack from '../../cli/theme';
-import { getProjectDir, readConfigFile, type WatchConfig } from '@wp-tester/config';
+import { getProjectDir, normalizeConfigPath, readConfigFile, type WatchConfig } from '@wp-tester/config';
 
 export interface WatchOptions {
   configPath: string;
   onRunTests: () => Promise<void>;
-}
-
-/**
- * Normalize a config path - if it's a directory, append wp-tester.json
- */
-function normalizeConfigPath(configPath: string): string {
-  const absolutePath = resolve(process.cwd(), configPath);
-
-  try {
-    const stats = statSync(absolutePath);
-    if (stats.isDirectory()) {
-      return join(absolutePath, 'wp-tester.json');
-    }
-  } catch {
-    // If stat fails, assume it's a file path
-  }
-
-  return absolutePath;
 }
 
 // Default patterns to exclude when watching for changes

--- a/packages/cli/src/commands/test/watcher.ts
+++ b/packages/cli/src/commands/test/watcher.ts
@@ -1,0 +1,160 @@
+import { watch, type FSWatcher } from 'fs';
+import * as clack from '../../cli/theme';
+import { resolveConfig, getProjectDir, readConfigFile } from '@wp-tester/config';
+
+export interface WatchOptions {
+  configPath: string;
+  onRunTests: () => Promise<void>;
+}
+
+// Patterns to ignore when watching for changes
+const IGNORE_PATTERNS = [
+  /node_modules/,
+  /\.git/,
+  /\.svn/,
+  /\.hg/,
+  /\.DS_Store/,
+  /Thumbs\.db/,
+  /\.idea/,
+  /\.vscode/,
+  /\.cache/,
+  /dist\//,
+  /build\//,
+  /coverage\//,
+  /\.log$/,
+  /\.tmp$/,
+  /\.temp$/,
+];
+
+function shouldIgnore(filePath: string): boolean {
+  return IGNORE_PATTERNS.some(pattern => pattern.test(filePath));
+}
+
+export async function runWatchMode(options: WatchOptions): Promise<void> {
+  const { configPath, onRunTests } = options;
+
+  // Resolve config to get the project directory
+  const config = await readConfigFile(configPath);
+  const projectDir = getProjectDir(config, configPath);
+
+  clack.log.info(`Watching for changes in: ${projectDir}`);
+  clack.log.info('Press Enter to re-run tests, or q to quit.\n');
+
+  let isRunning = false;
+  let pendingRun = false;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let watcher: FSWatcher | null = null;
+
+  const runTests = async () => {
+    if (isRunning) {
+      pendingRun = true;
+      return;
+    }
+
+    isRunning = true;
+    console.clear();
+    clack.log.info('Running tests...\n');
+
+    try {
+      await onRunTests();
+    } catch (error) {
+      // Tests may exit with non-zero code, which is expected
+      if (error instanceof Error && !error.message.includes('process.exit')) {
+        clack.log.error(`Error running tests: ${error.message}`);
+      }
+    } finally {
+      isRunning = false;
+      clack.log.info('\nWatching for changes... (Enter to re-run, q to quit)');
+
+      if (pendingRun) {
+        pendingRun = false;
+        await runTests();
+      }
+    }
+  };
+
+  const scheduleRun = () => {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+    }
+    // Debounce file changes - wait 300ms before running tests
+    debounceTimer = setTimeout(() => {
+      void runTests();
+    }, 300);
+  };
+
+  // Set up file watcher
+  try {
+    watcher = watch(projectDir, { recursive: true }, (eventType, filename) => {
+      if (filename && !shouldIgnore(filename)) {
+        clack.log.step(`File changed: ${filename}`);
+        scheduleRun();
+      }
+    });
+
+    watcher.on('error', (error) => {
+      clack.log.error(`Watcher error: ${error.message}`);
+    });
+  } catch (error) {
+    if (error instanceof Error) {
+      clack.log.error(`Failed to start watcher: ${error.message}`);
+    }
+    process.exit(1);
+  }
+
+  // Set up keyboard input handling
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.setEncoding('utf8');
+
+    process.stdin.on('data', (key: string) => {
+      // Handle Ctrl+C
+      if (key === '\u0003') {
+        cleanup();
+        process.exit(0);
+      }
+      // Handle 'q' or 'Q' to quit
+      if (key === 'q' || key === 'Q') {
+        cleanup();
+        process.exit(0);
+      }
+      // Handle Enter to re-run tests
+      if (key === '\r' || key === '\n') {
+        scheduleRun();
+      }
+    });
+  }
+
+  const cleanup = () => {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+    }
+    if (watcher) {
+      watcher.close();
+    }
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(false);
+    }
+    clack.log.info('\nWatch mode stopped.');
+  };
+
+  // Handle process termination
+  process.on('SIGINT', () => {
+    cleanup();
+    process.exit(0);
+  });
+
+  process.on('SIGTERM', () => {
+    cleanup();
+    process.exit(0);
+  });
+
+  // Run tests initially
+  await runTests();
+
+  // Keep the process alive
+  await new Promise(() => {
+    // This promise never resolves, keeping watch mode running
+  });
+}

--- a/packages/cli/src/commands/test/watcher.ts
+++ b/packages/cli/src/commands/test/watcher.ts
@@ -1,7 +1,7 @@
 import { watch, type FSWatcher } from 'fs';
 import picomatch from 'picomatch';
 import * as clack from '../../cli/theme';
-import { getProjectDir, readConfigFile, type WatchConfig } from '@wp-tester/config';
+import { getProjectDir, normalizeConfigPath, readConfigFile, type WatchConfig } from '@wp-tester/config';
 
 export interface WatchOptions {
   configPath: string;
@@ -60,8 +60,10 @@ export async function runWatchMode(options: WatchOptions): Promise<void> {
 
   // Resolve config to get the project directory and watch settings
   const config = await readConfigFile(configPath);
-  const projectDir = getProjectDir(config, configPath);
-  const watchConfig = config.watch;
+  // Normalize config path to handle directory paths (appends wp-tester.json if needed)
+  const normalizedConfigPath = normalizeConfigPath(configPath);
+  const projectDir = getProjectDir(config, normalizedConfigPath);
+  const watchConfig = config.tests.watch;
 
   // Create the file matcher
   const matcher = createWatchMatcher(watchConfig);
@@ -70,13 +72,13 @@ export async function runWatchMode(options: WatchOptions): Promise<void> {
   clack.log.info(`Watching for changes in: ${projectDir}`);
 
   if (watchConfig?.include) {
-    clack.log.step(`Include patterns: ${watchConfig.include.join(', ')}`);
+    clack.log.step(`Include patterns: ${watchConfig.include.join(", ")}`);
   }
   if (watchConfig?.exclude) {
-    clack.log.step(`Exclude patterns: ${watchConfig.exclude.join(', ')}`);
+    clack.log.step(`Exclude patterns: ${watchConfig.exclude.join(", ")}`);
   }
 
-  clack.log.info('Press Enter to re-run tests, or q to quit.\n');
+  clack.log.info("Press Enter to re-run tests, or q to quit.\n");
 
   let isRunning = false;
   let pendingRun = false;
@@ -91,18 +93,18 @@ export async function runWatchMode(options: WatchOptions): Promise<void> {
 
     isRunning = true;
     console.clear();
-    clack.log.info('Running tests...\n');
+    clack.log.info("Running tests...\n");
 
     try {
       await onRunTests();
     } catch (error) {
       // Tests may exit with non-zero code, which is expected
-      if (error instanceof Error && !error.message.includes('process.exit')) {
+      if (error instanceof Error && !error.message.includes("process.exit")) {
         clack.log.error(`Error running tests: ${error.message}`);
       }
     } finally {
       isRunning = false;
-      clack.log.info('\nWatching for changes... (Enter to re-run, q to quit)');
+      clack.log.info("\nWatching for changes... (Enter to re-run, q to quit)");
 
       if (pendingRun) {
         pendingRun = false;
@@ -130,7 +132,7 @@ export async function runWatchMode(options: WatchOptions): Promise<void> {
       }
     });
 
-    watcher.on('error', (error) => {
+    watcher.on("error", (error) => {
       clack.log.error(`Watcher error: ${error.message}`);
     });
   } catch (error) {
@@ -144,25 +146,35 @@ export async function runWatchMode(options: WatchOptions): Promise<void> {
   if (process.stdin.isTTY) {
     process.stdin.setRawMode(true);
     process.stdin.resume();
-    process.stdin.setEncoding('utf8');
+    process.stdin.setEncoding("utf8");
 
-    process.stdin.on('data', (key: string) => {
+    process.stdin.on("data", (key: string) => {
       // Handle Ctrl+C
-      if (key === '\u0003') {
+      if (key === "\u0003") {
         cleanup();
         process.exit(0);
       }
       // Handle 'q' or 'Q' to quit
-      if (key === 'q' || key === 'Q') {
+      if (key === "q" || key === "Q") {
         cleanup();
         process.exit(0);
       }
       // Handle Enter to re-run tests
-      if (key === '\r' || key === '\n') {
+      if (key === "\r" || key === "\n") {
         scheduleRun();
       }
     });
   }
+
+  const onSigint = () => {
+    cleanup();
+    process.exit(0);
+  };
+
+  const onSigterm = () => {
+    cleanup();
+    process.exit(0);
+  };
 
   const cleanup = () => {
     if (debounceTimer) {
@@ -174,19 +186,15 @@ export async function runWatchMode(options: WatchOptions): Promise<void> {
     if (process.stdin.isTTY) {
       process.stdin.setRawMode(false);
     }
+    process.off("SIGINT", onSigint);
+    process.off("SIGTERM", onSigterm);
     clack.log.info('\nWatch mode stopped.');
   };
 
   // Handle process termination
-  process.on('SIGINT', () => {
-    cleanup();
-    process.exit(0);
-  });
+  process.on("SIGINT", onSigint);
 
-  process.on('SIGTERM', () => {
-    cleanup();
-    process.exit(0);
-  });
+  process.on("SIGTERM", onSigterm);
 
   // Run tests initially
   await runTests();

--- a/packages/cli/src/commands/test/watcher.ts
+++ b/packages/cli/src/commands/test/watcher.ts
@@ -10,22 +10,13 @@ export interface WatchOptions {
 
 // Default patterns to exclude when watching for changes
 const DEFAULT_EXCLUDE_PATTERNS = [
-  'node_modules/**',
-  'vendor/**',
-  '.git/**',
-  '.svn/**',
-  '.hg/**',
-  'dist/**',
-  'build/**',
-  'coverage/**',
-  '.cache/**',
-  '.idea/**',
-  '.vscode/**',
+  '**/node_modules/**',
+  '**/vendor/**',
+  '**/.git/**',
+  '**/.svn/**',
+  '**/.hg/**',
   '**/.DS_Store',
   '**/Thumbs.db',
-  '**/*.log',
-  '**/*.tmp',
-  '**/*.temp',
 ];
 
 interface WatchMatcher {

--- a/packages/cli/src/commands/test/watcher.ts
+++ b/packages/cli/src/commands/test/watcher.ts
@@ -92,7 +92,10 @@ export async function runWatchMode(options: WatchOptions): Promise<void> {
     }
 
     isRunning = true;
-    console.clear();
+    // Clear screen and move cursor to top-left using ANSI escape codes
+    // \x1b[2J clears the entire screen, \x1b[3J clears scrollback, \x1b[H moves cursor to home
+    // This is more reliable than console.clear() in watch mode
+    process.stdout.write('\x1b[2J\x1b[3J\x1b[H');
     clack.log.info("Running tests...\n");
 
     try {
@@ -104,7 +107,7 @@ export async function runWatchMode(options: WatchOptions): Promise<void> {
       }
     } finally {
       isRunning = false;
-      clack.log.info("\nWatching for changes... (Enter to re-run, q to quit)");
+      clack.log.info("Watching for changes... (Enter to re-run, q to quit)");
 
       if (pendingRun) {
         pendingRun = false;
@@ -127,7 +130,6 @@ export async function runWatchMode(options: WatchOptions): Promise<void> {
   try {
     watcher = watch(projectDir, { recursive: true }, (eventType, filename) => {
       if (filename && matcher.shouldWatch(filename)) {
-        clack.log.step(`File changed: ${filename}`);
         scheduleRun();
       }
     });

--- a/packages/cli/src/commands/test/watcher.ts
+++ b/packages/cli/src/commands/test/watcher.ts
@@ -1,30 +1,11 @@
-import { watch, type FSWatcher, statSync } from 'fs';
-import { join, resolve } from 'path';
+import { watch, type FSWatcher } from 'fs';
 import picomatch from 'picomatch';
 import * as clack from '../../cli/theme';
-import { getProjectDir, readConfigFile, type WatchConfig } from '@wp-tester/config';
+import { getProjectDir, readConfigFile, normalizeConfigPath, type WatchConfig } from '@wp-tester/config';
 
 export interface WatchOptions {
   configPath: string;
   onRunTests: () => Promise<void>;
-}
-
-/**
- * Normalize a config path - if it's a directory, append wp-tester.json
- */
-function normalizeConfigPath(configPath: string): string {
-  const absolutePath = resolve(process.cwd(), configPath);
-
-  try {
-    const stats = statSync(absolutePath);
-    if (stats.isDirectory()) {
-      return join(absolutePath, 'wp-tester.json');
-    }
-  } catch {
-    // If stat fails, assume it's a file path
-  }
-
-  return absolutePath;
 }
 
 // Default patterns to exclude when watching for changes

--- a/packages/cli/src/commands/test/watcher.ts
+++ b/packages/cli/src/commands/test/watcher.ts
@@ -1,11 +1,30 @@
-import { watch, type FSWatcher } from 'fs';
+import { watch, type FSWatcher, statSync } from 'fs';
+import { join, resolve } from 'path';
 import picomatch from 'picomatch';
 import * as clack from '../../cli/theme';
-import { getProjectDir, normalizeConfigPath, readConfigFile, type WatchConfig } from '@wp-tester/config';
+import { getProjectDir, readConfigFile, type WatchConfig } from '@wp-tester/config';
 
 export interface WatchOptions {
   configPath: string;
   onRunTests: () => Promise<void>;
+}
+
+/**
+ * Normalize a config path - if it's a directory, append wp-tester.json
+ */
+function normalizeConfigPath(configPath: string): string {
+  const absolutePath = resolve(process.cwd(), configPath);
+
+  try {
+    const stats = statSync(absolutePath);
+    if (stats.isDirectory()) {
+      return join(absolutePath, 'wp-tester.json');
+    }
+  } catch {
+    // If stat fails, assume it's a file path
+  }
+
+  return absolutePath;
 }
 
 // Default patterns to exclude when watching for changes

--- a/packages/cli/src/commands/test/watcher.ts
+++ b/packages/cli/src/commands/test/watcher.ts
@@ -1,49 +1,118 @@
 import { watch, type FSWatcher } from 'fs';
+import path from 'path';
+import picomatch from 'picomatch';
 import * as clack from '../../cli/theme';
-import { resolveConfig, getProjectDir, readConfigFile } from '@wp-tester/config';
+import { getProjectDir, readConfigFile, type WatchConfig } from '@wp-tester/config';
 
 export interface WatchOptions {
   configPath: string;
   onRunTests: () => Promise<void>;
 }
 
-// Patterns to ignore when watching for changes
-const IGNORE_PATTERNS = [
-  /node_modules/,
-  /\.git/,
-  /\.svn/,
-  /\.hg/,
-  /\.DS_Store/,
-  /Thumbs\.db/,
-  /\.idea/,
-  /\.vscode/,
-  /\.cache/,
-  /dist\//,
-  /build\//,
-  /coverage\//,
-  /\.log$/,
-  /\.tmp$/,
-  /\.temp$/,
+// Default patterns to exclude when watching for changes
+const DEFAULT_EXCLUDE_PATTERNS = [
+  'node_modules/**',
+  'vendor/**',
+  '.git/**',
+  '.svn/**',
+  '.hg/**',
+  'dist/**',
+  'build/**',
+  'coverage/**',
+  '.cache/**',
+  '.idea/**',
+  '.vscode/**',
+  '**/.DS_Store',
+  '**/Thumbs.db',
+  '**/*.log',
+  '**/*.tmp',
+  '**/*.temp',
 ];
 
-function shouldIgnore(filePath: string): boolean {
-  return IGNORE_PATTERNS.some(pattern => pattern.test(filePath));
+interface WatchMatcher {
+  shouldWatch: (filePath: string) => boolean;
+}
+
+function createWatchMatcher(watchConfig?: WatchConfig): WatchMatcher {
+  // Merge default excludes with user-provided excludes
+  const excludePatterns = watchConfig?.exclude ?? DEFAULT_EXCLUDE_PATTERNS;
+  const includePatterns = watchConfig?.include;
+  const extensions = watchConfig?.extensions;
+
+  // Create picomatch matchers
+  const excludeMatcher = picomatch(excludePatterns, { dot: true });
+  const includeMatcher = includePatterns ? picomatch(
+    includePatterns.map(p => p.endsWith('/**') ? p : `${p}/**`),
+    { dot: true }
+  ) : null;
+
+  return {
+    shouldWatch: (filePath: string): boolean => {
+      // Normalize path separators for cross-platform compatibility
+      const normalizedPath = filePath.replace(/\\/g, '/');
+
+      // Check if file should be excluded
+      if (excludeMatcher(normalizedPath)) {
+        return false;
+      }
+
+      // Check extension filter if specified
+      if (extensions && extensions.length > 0) {
+        const ext = path.extname(normalizedPath);
+        if (!extensions.includes(ext)) {
+          return false;
+        }
+      }
+
+      // Check include patterns if specified
+      if (includeMatcher) {
+        return includeMatcher(normalizedPath);
+      }
+
+      // No include patterns means watch everything (that's not excluded)
+      return true;
+    },
+  };
 }
 
 export async function runWatchMode(options: WatchOptions): Promise<void> {
   const { configPath, onRunTests } = options;
 
-  // Resolve config to get the project directory
+  // Resolve config to get the project directory and watch settings
   const config = await readConfigFile(configPath);
   const projectDir = getProjectDir(config, configPath);
+  const watchConfig = config.watch;
 
-  clack.log.info(`Watching for changes in: ${projectDir}`);
+  // Create the file matcher
+  const matcher = createWatchMatcher(watchConfig);
+
+  // Determine what to watch
+  const watchDirs: string[] = [];
+  if (watchConfig?.include && watchConfig.include.length > 0) {
+    // Watch specific directories
+    for (const dir of watchConfig.include) {
+      watchDirs.push(path.resolve(projectDir, dir));
+    }
+    clack.log.info(`Watching directories: ${watchConfig.include.join(', ')}`);
+  } else {
+    // Watch the entire project directory
+    watchDirs.push(projectDir);
+    clack.log.info(`Watching for changes in: ${projectDir}`);
+  }
+
+  if (watchConfig?.exclude) {
+    clack.log.step(`Excluding: ${watchConfig.exclude.join(', ')}`);
+  }
+  if (watchConfig?.extensions) {
+    clack.log.step(`File extensions: ${watchConfig.extensions.join(', ')}`);
+  }
+
   clack.log.info('Press Enter to re-run tests, or q to quit.\n');
 
   let isRunning = false;
   let pendingRun = false;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-  let watcher: FSWatcher | null = null;
+  const watchers: FSWatcher[] = [];
 
   const runTests = async () => {
     if (isRunning) {
@@ -83,22 +152,30 @@ export async function runWatchMode(options: WatchOptions): Promise<void> {
     }, 300);
   };
 
-  // Set up file watcher
-  try {
-    watcher = watch(projectDir, { recursive: true }, (eventType, filename) => {
-      if (filename && !shouldIgnore(filename)) {
-        clack.log.step(`File changed: ${filename}`);
-        scheduleRun();
-      }
-    });
+  // Set up file watchers for each directory
+  for (const watchDir of watchDirs) {
+    try {
+      const watcher = watch(watchDir, { recursive: true }, (eventType, filename) => {
+        if (filename && matcher.shouldWatch(filename)) {
+          clack.log.step(`File changed: ${filename}`);
+          scheduleRun();
+        }
+      });
 
-    watcher.on('error', (error) => {
-      clack.log.error(`Watcher error: ${error.message}`);
-    });
-  } catch (error) {
-    if (error instanceof Error) {
-      clack.log.error(`Failed to start watcher: ${error.message}`);
+      watcher.on('error', (error) => {
+        clack.log.error(`Watcher error: ${error.message}`);
+      });
+
+      watchers.push(watcher);
+    } catch (error) {
+      if (error instanceof Error) {
+        clack.log.error(`Failed to watch ${watchDir}: ${error.message}`);
+      }
     }
+  }
+
+  if (watchers.length === 0) {
+    clack.log.error('Failed to start any file watchers');
     process.exit(1);
   }
 
@@ -130,7 +207,7 @@ export async function runWatchMode(options: WatchOptions): Promise<void> {
     if (debounceTimer) {
       clearTimeout(debounceTimer);
     }
-    if (watcher) {
+    for (const watcher of watchers) {
       watcher.close();
     }
     if (process.stdin.isTTY) {

--- a/packages/cli/src/commands/test/watcher.ts
+++ b/packages/cli/src/commands/test/watcher.ts
@@ -1,5 +1,4 @@
 import { watch, type FSWatcher } from 'fs';
-import path from 'path';
 import picomatch from 'picomatch';
 import * as clack from '../../cli/theme';
 import { getProjectDir, readConfigFile, type WatchConfig } from '@wp-tester/config';
@@ -37,14 +36,12 @@ function createWatchMatcher(watchConfig?: WatchConfig): WatchMatcher {
   // Merge default excludes with user-provided excludes
   const excludePatterns = watchConfig?.exclude ?? DEFAULT_EXCLUDE_PATTERNS;
   const includePatterns = watchConfig?.include;
-  const extensions = watchConfig?.extensions;
 
   // Create picomatch matchers
   const excludeMatcher = picomatch(excludePatterns, { dot: true });
-  const includeMatcher = includePatterns ? picomatch(
-    includePatterns.map(p => p.endsWith('/**') ? p : `${p}/**`),
-    { dot: true }
-  ) : null;
+  const includeMatcher = includePatterns
+    ? picomatch(includePatterns, { dot: true })
+    : null;
 
   return {
     shouldWatch: (filePath: string): boolean => {
@@ -54,14 +51,6 @@ function createWatchMatcher(watchConfig?: WatchConfig): WatchMatcher {
       // Check if file should be excluded
       if (excludeMatcher(normalizedPath)) {
         return false;
-      }
-
-      // Check extension filter if specified
-      if (extensions && extensions.length > 0) {
-        const ext = path.extname(normalizedPath);
-        if (!extensions.includes(ext)) {
-          return false;
-        }
       }
 
       // Check include patterns if specified
@@ -86,25 +75,14 @@ export async function runWatchMode(options: WatchOptions): Promise<void> {
   // Create the file matcher
   const matcher = createWatchMatcher(watchConfig);
 
-  // Determine what to watch
-  const watchDirs: string[] = [];
-  if (watchConfig?.include && watchConfig.include.length > 0) {
-    // Watch specific directories
-    for (const dir of watchConfig.include) {
-      watchDirs.push(path.resolve(projectDir, dir));
-    }
-    clack.log.info(`Watching directories: ${watchConfig.include.join(', ')}`);
-  } else {
-    // Watch the entire project directory
-    watchDirs.push(projectDir);
-    clack.log.info(`Watching for changes in: ${projectDir}`);
-  }
+  // Always watch the project directory, use matcher to filter files
+  clack.log.info(`Watching for changes in: ${projectDir}`);
 
-  if (watchConfig?.exclude) {
-    clack.log.step(`Excluding: ${watchConfig.exclude.join(', ')}`);
+  if (watchConfig?.include) {
+    clack.log.step(`Include patterns: ${watchConfig.include.join(', ')}`);
   }
-  if (watchConfig?.extensions) {
-    clack.log.step(`File extensions: ${watchConfig.extensions.join(', ')}`);
+  if (watchConfig?.exclude) {
+    clack.log.step(`Exclude patterns: ${watchConfig.exclude.join(', ')}`);
   }
 
   clack.log.info('Press Enter to re-run tests, or q to quit.\n');
@@ -112,7 +90,7 @@ export async function runWatchMode(options: WatchOptions): Promise<void> {
   let isRunning = false;
   let pendingRun = false;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-  const watchers: FSWatcher[] = [];
+  let watcher: FSWatcher | null = null;
 
   const runTests = async () => {
     if (isRunning) {
@@ -152,30 +130,22 @@ export async function runWatchMode(options: WatchOptions): Promise<void> {
     }, 300);
   };
 
-  // Set up file watchers for each directory
-  for (const watchDir of watchDirs) {
-    try {
-      const watcher = watch(watchDir, { recursive: true }, (eventType, filename) => {
-        if (filename && matcher.shouldWatch(filename)) {
-          clack.log.step(`File changed: ${filename}`);
-          scheduleRun();
-        }
-      });
-
-      watcher.on('error', (error) => {
-        clack.log.error(`Watcher error: ${error.message}`);
-      });
-
-      watchers.push(watcher);
-    } catch (error) {
-      if (error instanceof Error) {
-        clack.log.error(`Failed to watch ${watchDir}: ${error.message}`);
+  // Set up file watcher
+  try {
+    watcher = watch(projectDir, { recursive: true }, (eventType, filename) => {
+      if (filename && matcher.shouldWatch(filename)) {
+        clack.log.step(`File changed: ${filename}`);
+        scheduleRun();
       }
-    }
-  }
+    });
 
-  if (watchers.length === 0) {
-    clack.log.error('Failed to start any file watchers');
+    watcher.on('error', (error) => {
+      clack.log.error(`Watcher error: ${error.message}`);
+    });
+  } catch (error) {
+    if (error instanceof Error) {
+      clack.log.error(`Failed to start watcher: ${error.message}`);
+    }
     process.exit(1);
   }
 
@@ -207,7 +177,7 @@ export async function runWatchMode(options: WatchOptions): Promise<void> {
     if (debounceTimer) {
       clearTimeout(debounceTimer);
     }
-    for (const watcher of watchers) {
+    if (watcher) {
       watcher.close();
     }
     if (process.stdin.isTTY) {

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -2,7 +2,7 @@ import type { WPTesterConfig, Tests } from "./wp-tester-config";
 import type { ResolvedWPTesterConfig, ResolvedEnvironment, ResolvedTests, ResolvedPHPUnitConfig } from "./resolved-types";
 import type { BlueprintV1Declaration } from "@wp-playground/blueprints";
 import { readFile, writeFile, access, constants as fsConstants } from "fs/promises";
-import { existsSync } from "fs";
+import { existsSync, statSync } from "fs";
 import { join, dirname, resolve, isAbsolute } from "path";
 import { fileURLToPath } from "url";
 import { getProjectRootMount } from "./auto-mount";
@@ -91,6 +91,10 @@ export async function readConfigFile(path?: string): Promise<WPTesterConfig> {
   if (!path) {
     path = configPath();
   }
+
+  // Normalize the path (handles directory paths)
+  path = normalizeConfigPath(path);
+
   const content = await readFile(path, "utf8");
   return JSON.parse(content) as WPTesterConfig;
 }
@@ -113,6 +117,31 @@ export async function writeConfigFile(
  */
 export function getConfigPath(config: string): string {
   return isAbsolute(config) ? config : resolve(process.cwd(), config);
+}
+
+/**
+ * Normalize a config path to ensure it points to a file, not a directory.
+ * If the path is a directory, appends 'wp-tester.json' to it.
+ * Used by readConfigFile, resolveConfig, and the test watcher to handle
+ * directory paths passed via --config flag.
+ *
+ * @param configPath - Path to config file or directory (relative or absolute)
+ * @returns Absolute path to the config file
+ */
+export function normalizeConfigPath(configPath: string): string {
+  const absolutePath = getConfigPath(configPath);
+
+  // Check if path is a directory (synchronous)
+  try {
+    const stats = statSync(absolutePath);
+    if (stats.isDirectory()) {
+      return join(absolutePath, 'wp-tester.json');
+    }
+  } catch {
+    // If stat fails, assume it's a file path
+  }
+
+  return absolutePath;
 }
 
 /**
@@ -202,7 +231,9 @@ export async function resolveConfig(
   let configPath: string | undefined;
 
   if (typeof config === "string") {
-    configPath = getConfigPath(config);
+    // Normalize the path (handles directory paths)
+    configPath = normalizeConfigPath(config);
+
     const content = await readFile(configPath, "utf8");
     resolvedConfig = JSON.parse(content) as WPTesterConfig;
   } else {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -34,6 +34,7 @@ export {
   getProjectDir,
   getConfigDir,
   getConfigPath,
+  normalizeConfigPath,
   resolveAbsolute,
 } from "./config";
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -10,6 +10,7 @@ export type {
   Mount,
   Blueprint,
   JsonReporterOptions,
+  WatchConfig,
 } from "./types";
 
 // Resolved types (after resolveConfig())

--- a/packages/config/src/schema.json
+++ b/packages/config/src/schema.json
@@ -3455,6 +3455,34 @@
     "tests": {
       "$ref": "#/definitions/Tests",
       "description": "Test suites to execute"
+    },
+    "watch": {
+      "description": "Watch mode configuration.\nControls which files are watched when using --watch flag.",
+      "properties": {
+        "include": {
+          "description": "Directories to watch for changes (relative to projectHostPath).\nIf not specified, watches the entire projectHostPath directory.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "exclude": {
+          "description": "Patterns to exclude from watching.\nSupports glob patterns.",
+          "default": ["node_modules/**", "vendor/**", ".git/**", "dist/**", "build/**"],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "extensions": {
+          "description": "File extensions to watch.\nIf specified, only files with these extensions trigger re-runs.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
     }
   },
   "required": [

--- a/packages/config/src/schema.json
+++ b/packages/config/src/schema.json
@@ -3460,22 +3460,15 @@
       "description": "Watch mode configuration.\nControls which files are watched when using --watch flag.",
       "properties": {
         "include": {
-          "description": "Directories to watch for changes (relative to projectHostPath).\nIf not specified, watches the entire projectHostPath directory.",
+          "description": "Glob patterns for files/directories to watch (relative to projectHostPath).\nIf not specified, watches all files in the projectHostPath directory.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "exclude": {
-          "description": "Patterns to exclude from watching.\nSupports glob patterns.",
+          "description": "Glob patterns to exclude from watching.",
           "default": ["node_modules/**", "vendor/**", ".git/**", "dist/**", "build/**"],
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "extensions": {
-          "description": "File extensions to watch.\nIf specified, only files with these extensions trigger re-runs.",
           "items": {
             "type": "string"
           },

--- a/packages/config/src/schema.json
+++ b/packages/config/src/schema.json
@@ -3468,7 +3468,7 @@
         },
         "exclude": {
           "description": "Glob patterns to exclude from watching.",
-          "default": ["node_modules/**", "vendor/**", ".git/**", "dist/**", "build/**"],
+          "default": ["**/node_modules/**", "**/vendor/**", "**/.git/**"],
           "items": {
             "type": "string"
           },

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -10,6 +10,7 @@ export type {
   Mount,
   Blueprint,
   JsonReporterOptions,
+  WatchConfig,
 } from "./wp-tester-config";
 
 export type {

--- a/packages/config/src/wp-tester-config.ts
+++ b/packages/config/src/wp-tester-config.ts
@@ -192,6 +192,33 @@ export interface Environment {
 }
 
 /**
+ * Watch mode configuration for automatic test re-runs.
+ */
+export interface WatchConfig {
+  /**
+   * Directories to watch for changes (relative to projectHostPath).
+   * If not specified, watches the entire projectHostPath directory.
+   * @example ["src", "tests", "includes"]
+   */
+  include?: string[];
+
+  /**
+   * Patterns to exclude from watching.
+   * Supports glob patterns.
+   * @example ["vendor/**", "node_modules/**", "*.log"]
+   * @default ["node_modules/**", "vendor/**", ".git/**", "dist/**", "build/**"]
+   */
+  exclude?: string[];
+
+  /**
+   * File extensions to watch.
+   * If specified, only files with these extensions trigger re-runs.
+   * @example [".php", ".js", ".css"]
+   */
+  extensions?: string[];
+}
+
+/**
  * Complete wp-tester configuration.
  * This is the root configuration object for wp-tester.json files.
  */
@@ -251,4 +278,10 @@ export interface WPTesterConfig {
    * @default ["default"]
    */
   reporters?: Reporter[];
+
+  /**
+   * Watch mode configuration.
+   * Controls which files are watched when using --watch flag.
+   */
+  watch?: WatchConfig;
 }

--- a/packages/config/src/wp-tester-config.ts
+++ b/packages/config/src/wp-tester-config.ts
@@ -127,6 +127,12 @@ export interface Tests {
    * When undefined, PHPUnit tests are disabled.
    */
   phpunit?: PHPUnitConfig;
+
+  /**
+   * Watch mode configuration.
+   * Controls which files are watched when using --watch flag.
+   */
+  watch?: WatchConfig;
 }
 
 /**
@@ -267,10 +273,4 @@ export interface WPTesterConfig {
    * @default ["default"]
    */
   reporters?: Reporter[];
-
-  /**
-   * Watch mode configuration.
-   * Controls which files are watched when using --watch flag.
-   */
-  watch?: WatchConfig;
 }

--- a/packages/config/src/wp-tester-config.ts
+++ b/packages/config/src/wp-tester-config.ts
@@ -196,26 +196,15 @@ export interface Environment {
  */
 export interface WatchConfig {
   /**
-   * Directories to watch for changes (relative to projectHostPath).
-   * If not specified, watches the entire projectHostPath directory.
-   * @example ["src", "tests", "includes"]
+   * Glob patterns for files/directories to watch (relative to projectHostPath).
+   * If not specified, watches all files in the projectHostPath directory.
    */
   include?: string[];
 
   /**
-   * Patterns to exclude from watching.
-   * Supports glob patterns.
-   * @example ["vendor/**", "node_modules/**", "*.log"]
-   * @default ["node_modules/**", "vendor/**", ".git/**", "dist/**", "build/**"]
+   * Glob patterns to exclude from watching.
    */
   exclude?: string[];
-
-  /**
-   * File extensions to watch.
-   * If specified, only files with these extensions trigger re-runs.
-   * @example [".php", ".js", ".css"]
-   */
-  extensions?: string[];
 }
 
 /**

--- a/packages/config/tests/config-file-io.spec.ts
+++ b/packages/config/tests/config-file-io.spec.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readConfigFile, resolveConfig, normalizeConfigPath } from '../src/config';
+import { mkdir, writeFile, rm } from 'fs/promises';
+import { join } from 'path';
+import * as os from 'os';
+import type { WPTesterConfig } from '../src/types';
+
+describe('Config File I/O', () => {
+  let testDir: string;
+  let configDir: string;
+  let configFile: string;
+  const testConfig: WPTesterConfig = {
+    environments: [
+      {
+        name: 'Test Environment',
+        blueprint: {
+          preferredVersions: {
+            php: 'latest',
+            wp: 'latest',
+          },
+        },
+      },
+    ],
+    tests: {},
+    reporters: ['default'],
+  };
+
+  beforeEach(async () => {
+    // Create a temporary directory for testing
+    testDir = await os.tmpdir();
+    configDir = join(testDir, `wp-tester-test-${Date.now()}`);
+    await mkdir(configDir, { recursive: true });
+    configFile = join(configDir, 'wp-tester.json');
+    await writeFile(configFile, JSON.stringify(testConfig, null, 2));
+  });
+
+  afterEach(async () => {
+    // Clean up test directory
+    await rm(configDir, { recursive: true, force: true });
+  });
+
+  describe('readConfigFile', () => {
+    it('should read config from file path', async () => {
+      const config = await readConfigFile(configFile);
+      expect(config).toEqual(testConfig);
+    });
+
+    it('should read config from directory path', async () => {
+      const config = await readConfigFile(configDir);
+      expect(config).toEqual(testConfig);
+    });
+
+    it('should throw error if directory does not contain wp-tester.json', async () => {
+      const emptyDir = join(testDir, `wp-tester-empty-${Date.now()}`);
+      await mkdir(emptyDir, { recursive: true });
+
+      await expect(readConfigFile(emptyDir)).rejects.toThrow();
+
+      await rm(emptyDir, { recursive: true, force: true });
+    });
+
+    it('should throw error if file does not exist', async () => {
+      const nonExistentFile = join(configDir, 'non-existent.json');
+      await expect(readConfigFile(nonExistentFile)).rejects.toThrow();
+    });
+  });
+
+  describe('resolveConfig', () => {
+    it('should resolve config from file path', async () => {
+      const resolved = await resolveConfig(configFile);
+      expect(resolved.environments).toHaveLength(1);
+      expect(resolved.environments[0].name).toBe('Test Environment');
+      expect(resolved.projectHostPath).toBe(configDir);
+    });
+
+    it('should resolve config from directory path', async () => {
+      const resolved = await resolveConfig(configDir);
+      expect(resolved.environments).toHaveLength(1);
+      expect(resolved.environments[0].name).toBe('Test Environment');
+      expect(resolved.projectHostPath).toBe(configDir);
+    });
+
+    it('should resolve config from object', async () => {
+      const resolved = await resolveConfig(testConfig);
+      expect(resolved.environments).toHaveLength(1);
+      expect(resolved.environments[0].name).toBe('Test Environment');
+    });
+
+    it('should throw error if directory does not contain wp-tester.json', async () => {
+      const emptyDir = join(testDir, `wp-tester-empty-${Date.now()}`);
+      await mkdir(emptyDir, { recursive: true });
+
+      await expect(resolveConfig(emptyDir)).rejects.toThrow();
+
+      await rm(emptyDir, { recursive: true, force: true });
+    });
+  });
+
+  describe('normalizeConfigPath', () => {
+    it('should return file path as-is when given a file path', () => {
+      const normalized = normalizeConfigPath(configFile);
+      expect(normalized).toBe(configFile);
+    });
+
+    it('should append wp-tester.json when given a directory path', () => {
+      const normalized = normalizeConfigPath(configDir);
+      expect(normalized).toBe(configFile);
+    });
+
+    it('should handle relative file paths', () => {
+      const relativePath = 'wp-tester.json';
+      const normalized = normalizeConfigPath(relativePath);
+      expect(normalized).toBe(join(process.cwd(), relativePath));
+    });
+
+    it('should return path as-is if stat fails (non-existent path)', () => {
+      const nonExistentPath = '/non/existent/path/wp-tester.json';
+      const normalized = normalizeConfigPath(nonExistentPath);
+      expect(normalized).toBe(nonExistentPath);
+    });
+  });
+});

--- a/scripts/test-package-install.js
+++ b/scripts/test-package-install.js
@@ -57,16 +57,33 @@ function packPackage(packagePath, packageName) {
 }
 
 /**
- * Install package from tarball in a temp directory
+ * Install package from tarball in a temp directory, using local tarballs for monorepo dependencies
  * @param {string} tarballPath - Path to package tarball
  * @param {string} packageName - Package name for error messages
+ * @param {Map<string, string>} packageTarballs - Map of package names to their tarball paths
+ * @param {object} packageJson - Package.json to check for local dependencies
  * @returns {string} - Path to temp directory
  */
-function installPackage(tarballPath, packageName) {
+function installPackage(tarballPath, packageName, packageTarballs, packageJson) {
   const tempDir = mkdtempSync(join(tmpdir(), 'wp-tester-pkg-test-'));
 
   try {
-    execSync(`npm install --production --silent ${tarballPath}`, {
+    // Find local dependencies that need to be installed from tarballs
+    const allDeps = {
+      ...packageJson.dependencies,
+      ...packageJson.peerDependencies,
+    };
+
+    const localDepTarballs = [];
+    for (const depName of Object.keys(allDeps || {})) {
+      if (packageTarballs.has(depName)) {
+        localDepTarballs.push(packageTarballs.get(depName));
+      }
+    }
+
+    // Install local dependencies first, then the package itself
+    const allTarballs = [...localDepTarballs, tarballPath].join(' ');
+    execSync(`npm install --production --silent ${allTarballs}`, {
       cwd: tempDir,
       stdio: 'pipe',
     });
@@ -131,18 +148,16 @@ function testImport(tempDir, packageName, packageJson) {
 /**
  * Test a single package
  * @param {object} pkg - Package info
+ * @param {Map<string, string>} packageTarballs - Map of package names to their tarball paths
  * @returns {Promise<{success: boolean, error?: Error}>}
  */
-async function testPackage(pkg) {
+async function testPackage(pkg, packageTarballs) {
   let tempDir = null;
-  let tarballPath = null;
+  const tarballPath = packageTarballs.get(pkg.name);
 
   try {
-    // Pack the package
-    tarballPath = packPackage(pkg.path, pkg.name);
-
-    // Install in temp directory
-    tempDir = installPackage(tarballPath, pkg.name);
+    // Install in temp directory with local dependencies
+    tempDir = installPackage(tarballPath, pkg.name, packageTarballs, pkg.packageJson);
 
     // Try to import it
     testImport(tempDir, pkg.name, pkg.packageJson);
@@ -151,12 +166,9 @@ async function testPackage(pkg) {
   } catch (err) {
     return { success: false, error: err };
   } finally {
-    // Cleanup
+    // Cleanup temp directory
     if (tempDir) {
       rmSync(tempDir, { recursive: true, force: true });
-    }
-    if (tarballPath) {
-      rmSync(tarballPath, { force: true });
     }
   }
 }
@@ -176,11 +188,28 @@ async function main() {
     return;
   }
 
+  // Pack all packages first so we can use local tarballs for dependencies
+  const packageTarballs = new Map();
+  for (const pkg of publicPackages) {
+    try {
+      const tarballPath = packPackage(pkg.path, pkg.name);
+      packageTarballs.set(pkg.name, tarballPath);
+    } catch (err) {
+      console.log(`✗ ${pkg.name.padEnd(25)} - failed to pack`);
+      console.log(`  ${err.message}\n`);
+    }
+  }
+
   const results = [];
 
   // Test each package
   for (const pkg of publicPackages) {
-    const result = await testPackage(pkg);
+    if (!packageTarballs.has(pkg.name)) {
+      results.push({ pkg, success: false, error: new Error('Failed to pack') });
+      continue;
+    }
+
+    const result = await testPackage(pkg, packageTarballs);
     results.push({ pkg, ...result });
 
     if (result.success) {
@@ -189,6 +218,11 @@ async function main() {
       console.log(`✗ ${pkg.name.padEnd(25)} - failed to import`);
       console.log(`  ${result.error.message}\n`);
     }
+  }
+
+  // Cleanup all tarballs
+  for (const tarballPath of packageTarballs.values()) {
+    rmSync(tarballPath, { force: true });
   }
 
   // Summary

--- a/scripts/test-package-install.js
+++ b/scripts/test-package-install.js
@@ -57,33 +57,16 @@ function packPackage(packagePath, packageName) {
 }
 
 /**
- * Install package from tarball in a temp directory, using local tarballs for monorepo dependencies
+ * Install package from tarball in a temp directory
  * @param {string} tarballPath - Path to package tarball
  * @param {string} packageName - Package name for error messages
- * @param {Map<string, string>} packageTarballs - Map of package names to their tarball paths
- * @param {object} packageJson - Package.json to check for local dependencies
  * @returns {string} - Path to temp directory
  */
-function installPackage(tarballPath, packageName, packageTarballs, packageJson) {
+function installPackage(tarballPath, packageName) {
   const tempDir = mkdtempSync(join(tmpdir(), 'wp-tester-pkg-test-'));
 
   try {
-    // Find local dependencies that need to be installed from tarballs
-    const allDeps = {
-      ...packageJson.dependencies,
-      ...packageJson.peerDependencies,
-    };
-
-    const localDepTarballs = [];
-    for (const depName of Object.keys(allDeps || {})) {
-      if (packageTarballs.has(depName)) {
-        localDepTarballs.push(packageTarballs.get(depName));
-      }
-    }
-
-    // Install local dependencies first, then the package itself
-    const allTarballs = [...localDepTarballs, tarballPath].join(' ');
-    execSync(`npm install --production --silent ${allTarballs}`, {
+    execSync(`npm install --production --silent ${tarballPath}`, {
       cwd: tempDir,
       stdio: 'pipe',
     });
@@ -148,16 +131,18 @@ function testImport(tempDir, packageName, packageJson) {
 /**
  * Test a single package
  * @param {object} pkg - Package info
- * @param {Map<string, string>} packageTarballs - Map of package names to their tarball paths
  * @returns {Promise<{success: boolean, error?: Error}>}
  */
-async function testPackage(pkg, packageTarballs) {
+async function testPackage(pkg) {
   let tempDir = null;
-  const tarballPath = packageTarballs.get(pkg.name);
+  let tarballPath = null;
 
   try {
-    // Install in temp directory with local dependencies
-    tempDir = installPackage(tarballPath, pkg.name, packageTarballs, pkg.packageJson);
+    // Pack the package
+    tarballPath = packPackage(pkg.path, pkg.name);
+
+    // Install in temp directory
+    tempDir = installPackage(tarballPath, pkg.name);
 
     // Try to import it
     testImport(tempDir, pkg.name, pkg.packageJson);
@@ -166,9 +151,12 @@ async function testPackage(pkg, packageTarballs) {
   } catch (err) {
     return { success: false, error: err };
   } finally {
-    // Cleanup temp directory
+    // Cleanup
     if (tempDir) {
       rmSync(tempDir, { recursive: true, force: true });
+    }
+    if (tarballPath) {
+      rmSync(tarballPath, { force: true });
     }
   }
 }
@@ -188,28 +176,11 @@ async function main() {
     return;
   }
 
-  // Pack all packages first so we can use local tarballs for dependencies
-  const packageTarballs = new Map();
-  for (const pkg of publicPackages) {
-    try {
-      const tarballPath = packPackage(pkg.path, pkg.name);
-      packageTarballs.set(pkg.name, tarballPath);
-    } catch (err) {
-      console.log(`✗ ${pkg.name.padEnd(25)} - failed to pack`);
-      console.log(`  ${err.message}\n`);
-    }
-  }
-
   const results = [];
 
   // Test each package
   for (const pkg of publicPackages) {
-    if (!packageTarballs.has(pkg.name)) {
-      results.push({ pkg, success: false, error: new Error('Failed to pack') });
-      continue;
-    }
-
-    const result = await testPackage(pkg, packageTarballs);
+    const result = await testPackage(pkg);
     results.push({ pkg, ...result });
 
     if (result.success) {
@@ -218,11 +189,6 @@ async function main() {
       console.log(`✗ ${pkg.name.padEnd(25)} - failed to import`);
       console.log(`  ${result.error.message}\n`);
     }
-  }
-
-  // Cleanup all tarballs
-  for (const tarballPath of packageTarballs.values()) {
-    rmSync(tarballPath, { force: true });
   }
 
   // Summary


### PR DESCRIPTION
Adds --watch (-w) flag that automatically re-runs tests when files change.

- Tests run immediately on startup, then re-run on file changes (300ms debounce)
- Press Enter to manually re-run, q to quit
- Configurable include/exclude glob patterns via tests.watch config
- Default excludes: node_modules, vendor, .git
