### PR TITLE
Add $schema to generated config files for IDE autocomplete

### DIFF
--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -62,6 +62,8 @@ export function getSchemaPath(importMetaUrl?: string): string {
 
 export function getDefaultConfig(): WPTesterConfig {
   return {
+    $schema:
+      "https://raw.githubusercontent.com/bgrgicak/wp-tester/trunk/packages/config/src/schema.json",
     environments: [
       {
         name: "Latest WordPress and PHP",


### PR DESCRIPTION
The setup command now includes a $schema property pointing to the JSON schema at the GitHub raw URL. This enables IDE autocomplete and validation for wp-tester.json configuration files.

Fixes #134