### PR TITLE
Fix PHPUnit single file/directory test execution

### DIFF
--- a/packages/phpunit/src/runner.ts
+++ b/packages/phpunit/src/runner.ts
@@ -128,26 +128,9 @@ async function runPhpunitTestsForEnvironment(
     // Translate file/directory paths from host to VFS
     const phpunitArgs = config.tests.phpunit!.phpunitArgs;
     if (phpunitArgs && phpunitArgs.length > 0) {
-      const translatedArgs = phpunitArgs.map(arg => {
-        // Check if this argument looks like a file or directory path
-        // PHPUnit accepts test files/directories as positional arguments
-        // Arguments starting with '-' are flags/options, not paths
-        // Paths typically end with .php, /, or are directory names like 'tests'
-        if (!arg.startsWith('-')) {
-          // Check if it's likely a path (contains path separators, ends with .php, or common test directories)
-          const looksLikePath = arg.includes('/') || arg.includes('\\') ||
-                                arg.endsWith('.php') ||
-                                arg === 'tests' || arg === 'test';
+      // Use the helper to translate arguments
+      const translatedArgs = await translatePhpunitArgs(phpunitArgs, config, playground);
 
-          if (looksLikePath) {
-            // Convert relative path to absolute host path first
-            const absoluteHostPath = resolveAbsolute(arg, config.projectHostPath);
-            // Then translate to VFS path
-            return hostToVfs(absoluteHostPath, config);
-          }
-        }
-        return arg;
-      });
       cliArgs.push(...translatedArgs);
     }
 
@@ -396,3 +379,101 @@ export async function runPhpunitTests(
   // Import mergeReports for multiple environments
   return mergeReports(reports);
 }
+
+/**
+ * PHPUnit flags that are boolean (do not take a value).
+ * If a flag is NOT in this list, we assume it takes a value,
+ * and therefore the next argument should NOT be translated as a path.
+ */
+const booleanFlags = new Set([
+  '--teamcity', '--debug', '--verbose', '--testdox',
+  '--stderr', '--stop-on-error', '--stop-on-failure', '--stop-on-warning',
+  '--stop-on-defect', '--stop-on-risky', '--stop-on-skipped', '--stop-on-incomplete',
+  '--stop-on-deprecation', '--stop-on-notice', // Added in recent versions
+  '--fail-on-warning', '--fail-on-risky', '--fail-on-incomplete', '--fail-on-skipped',
+  '--fail-on-deprecation', '--fail-on-notice', // Added in recent versions
+  '--strict-coverage', '--strict-global-state', '--disallow-test-output',
+  '--disallow-resource-usage', '--enforce-time-limit',
+  '--process-isolation', '--no-globals-backup', '--static-backup',
+  '--no-configuration', '--no-coverage', '--no-logging', '--no-interaction',
+  '--no-extensions', '--no-output', '--dont-report-useless-tests',
+  '--no-progress', // Added
+  '--display-deprecations', '--display-errors', '--display-incomplete', // Added
+  '--display-notices', '--display-skipped', '--display-warnings', // Added
+  '--strict',
+  '--help', '--version',
+  '--list-groups', '--list-suites', '--list-tests', '--list-tests-xml',
+  // Colors often handled as boolean in simple usage
+]);
+
+// Minimal interface for Playground client
+interface PlaygroundClient {
+  fileExists(path: string): Promise<boolean>;
+}
+
+/**
+ * Translate PHPUnit arguments to map host paths to VFS paths
+ *
+ * @param args - Original arguments
+ * @param config - Resolved configuration
+ * @param playground - Playground client for checking VFS file existence
+ * @returns Translated arguments
+ */
+export async function translatePhpunitArgs(
+  args: string[],
+  config: ResolvedWPTesterConfig,
+  playground: PlaygroundClient
+): Promise<string[]> {
+  const translatedArgs: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    // Don't translate flags
+    if (arg.startsWith('-')) {
+      translatedArgs.push(arg);
+      continue;
+    }
+
+    // Check if the previous argument was a flag that takes a value
+    const prevArg = args[i - 1];
+    if (prevArg?.startsWith('-') && !prevArg.includes('=')) {
+      // If the previous flag is NOT a known boolean flag, assume it takes a value
+      const flagName = prevArg.split('=')[0];
+      if (!booleanFlags.has(flagName)) {
+        translatedArgs.push(arg); // This is the flag's value, not a path
+        continue;
+      }
+    }
+
+    // Translate arguments that look like file/directory paths
+    const looksLikePath = arg.includes('/') ||
+                          arg.endsWith('.php') ||
+                          arg === 'tests' || arg === 'test';
+
+    if (looksLikePath) {
+      const absoluteHostPath = resolveAbsolute(arg, config.projectHostPath);
+      const vfsPath = hostToVfs(absoluteHostPath, config);
+
+      try {
+        // Validate that the file actually exists in the VFS
+        const exists = await playground.fileExists(vfsPath);
+        if (exists) {
+            translatedArgs.push(vfsPath);
+            continue;
+        }
+      } catch (error) {
+        // Ignore validation errors and fallback to original arg (or should we?)
+        // If file check fails, it's safer to probably not translate it if we are strict,
+        // but existing behavior was "looksLikePath -> translate".
+        // If we add this check, we might break things that "look like path" but aren't files YET?
+        // But for running tests, the files must exist.
+      }
+    }
+
+    translatedArgs.push(arg);
+  }
+
+  return translatedArgs;
+}
+

--- a/packages/phpunit/src/runner.ts
+++ b/packages/phpunit/src/runner.ts
@@ -125,9 +125,30 @@ async function runPhpunitTestsForEnvironment(
     }
 
     // Append additional PHPUnit arguments from config
+    // Translate file/directory paths from host to VFS
     const phpunitArgs = config.tests.phpunit!.phpunitArgs;
     if (phpunitArgs && phpunitArgs.length > 0) {
-      cliArgs.push(...phpunitArgs);
+      const translatedArgs = phpunitArgs.map(arg => {
+        // Check if this argument looks like a file or directory path
+        // PHPUnit accepts test files/directories as positional arguments
+        // Arguments starting with '-' are flags/options, not paths
+        // Paths typically end with .php, /, or are directory names like 'tests'
+        if (!arg.startsWith('-')) {
+          // Check if it's likely a path (contains path separators, ends with .php, or common test directories)
+          const looksLikePath = arg.includes('/') || arg.includes('\\') ||
+                                arg.endsWith('.php') ||
+                                arg === 'tests' || arg === 'test';
+
+          if (looksLikePath) {
+            // Convert relative path to absolute host path first
+            const absoluteHostPath = resolveAbsolute(arg, config.projectHostPath);
+            // Then translate to VFS path
+            return hostToVfs(absoluteHostPath, config);
+          }
+        }
+        return arg;
+      });
+      cliArgs.push(...translatedArgs);
     }
 
     // Create streaming reporter

--- a/packages/phpunit/src/runner.ts
+++ b/packages/phpunit/src/runner.ts
@@ -125,13 +125,13 @@ async function runPhpunitTestsForEnvironment(
     }
 
     // Append additional PHPUnit arguments from config
-    // Translate file/directory paths from host to VFS
+    // Resolve file/directory paths from host to VFS
     const phpunitArgs = config.tests.phpunit!.phpunitArgs;
     if (phpunitArgs && phpunitArgs.length > 0) {
-      // Use the helper to translate arguments
-      const translatedArgs = await translatePhpunitArgs(phpunitArgs, config, playground);
+      // Use the helper to resolve arguments
+      const resolvedArgs = await resolvePhpunitArgs(phpunitArgs, config, playground);
 
-      cliArgs.push(...translatedArgs);
+      cliArgs.push(...resolvedArgs);
     }
 
     // Create streaming reporter
@@ -383,7 +383,7 @@ export async function runPhpunitTests(
 /**
  * PHPUnit flags that are boolean (do not take a value).
  * If a flag is NOT in this list, we assume it takes a value,
- * and therefore the next argument should NOT be translated as a path.
+ * and therefore the next argument should NOT be resolved as a path.
  */
 const booleanFlags = new Set([
   '--teamcity', '--debug', '--verbose', '--testdox',
@@ -412,26 +412,26 @@ interface PlaygroundClient {
 }
 
 /**
- * Translate PHPUnit arguments to map host paths to VFS paths
+ * Resolve PHPUnit arguments to map host paths to VFS paths
  *
  * @param args - Original arguments
  * @param config - Resolved configuration
  * @param playground - Playground client for checking VFS file existence
- * @returns Translated arguments
+ * @returns Resolved arguments
  */
-export async function translatePhpunitArgs(
+export async function resolvePhpunitArgs(
   args: string[],
   config: ResolvedWPTesterConfig,
   playground: PlaygroundClient
 ): Promise<string[]> {
-  const translatedArgs: string[] = [];
+  const resolvedArgs: string[] = [];
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
 
-    // Don't translate flags
+    // Don't resolve flags
     if (arg.startsWith('-')) {
-      translatedArgs.push(arg);
+      resolvedArgs.push(arg);
       continue;
     }
 
@@ -441,12 +441,12 @@ export async function translatePhpunitArgs(
       // If the previous flag is NOT a known boolean flag, assume it takes a value
       const flagName = prevArg.split('=')[0];
       if (!booleanFlags.has(flagName)) {
-        translatedArgs.push(arg); // This is the flag's value, not a path
+        resolvedArgs.push(arg); // This is the flag's value, not a path
         continue;
       }
     }
 
-    // Translate arguments that look like file/directory paths
+    // Resolve arguments that look like file/directory paths
     const looksLikePath = arg.includes('/') ||
                           arg.endsWith('.php') ||
                           arg === 'tests' || arg === 'test';
@@ -459,21 +459,21 @@ export async function translatePhpunitArgs(
         // Validate that the file actually exists in the VFS
         const exists = await playground.fileExists(vfsPath);
         if (exists) {
-            translatedArgs.push(vfsPath);
+            resolvedArgs.push(vfsPath);
             continue;
         }
       } catch {
         // Ignore validation errors and fallback to original arg (or should we?)
-        // If file check fails, it's safer to probably not translate it if we are strict,
-        // but existing behavior was "looksLikePath -> translate".
+        // If file check fails, it's safer to probably not resolve it if we are strict,
+        // but existing behavior was "looksLikePath -> resolve".
         // If we add this check, we might break things that "look like path" but aren't files YET?
         // But for running tests, the files must exist.
       }
     }
 
-    translatedArgs.push(arg);
+    resolvedArgs.push(arg);
   }
 
-  return translatedArgs;
+  return resolvedArgs;
 }
 

--- a/packages/phpunit/src/runner.ts
+++ b/packages/phpunit/src/runner.ts
@@ -298,8 +298,8 @@ async function runPhpunitTestsForEnvironment(
       await new Promise<void>((resolve) => {
         runtime.server.close(() => resolve());
       });
-    } catch (error) {
-      console.error("Error closing server:", error);
+    } catch {
+      console.error("Error closing server:");
     }
   }
 }
@@ -462,7 +462,7 @@ export async function translatePhpunitArgs(
             translatedArgs.push(vfsPath);
             continue;
         }
-      } catch (error) {
+      } catch {
         // Ignore validation errors and fallback to original arg (or should we?)
         // If file check fails, it's safer to probably not translate it if we are strict,
         // but existing behavior was "looksLikePath -> translate".

--- a/packages/phpunit/src/runner.ts
+++ b/packages/phpunit/src/runner.ts
@@ -298,7 +298,7 @@ async function runPhpunitTestsForEnvironment(
       await new Promise<void>((resolve) => {
         runtime.server.close(() => resolve());
       });
-    } catch(error) {
+    } catch (error) {
       console.error("Error closing server:", error);
     }
   }

--- a/packages/phpunit/src/runner.ts
+++ b/packages/phpunit/src/runner.ts
@@ -298,8 +298,8 @@ async function runPhpunitTestsForEnvironment(
       await new Promise<void>((resolve) => {
         runtime.server.close(() => resolve());
       });
-    } catch {
-      console.error("Error closing server:");
+    } catch(error) {
+      console.error("Error closing server:", error);
     }
   }
 }

--- a/packages/phpunit/tests/integration/run-phpunit-tests.spec.ts
+++ b/packages/phpunit/tests/integration/run-phpunit-tests.spec.ts
@@ -192,6 +192,103 @@ describe("runPhpunitTests integration", () => {
 			expect(report.results.summary.failed).toBe(0);
 		}
 	);
+
+	it(
+		"should handle phpunitArgs with flags that have path-like values",
+		async () => {
+			// Test that flag values are NOT translated even if they look like paths
+			// Example: --filter could have a value like "MyNamespace\Tests"
+			const report = await runPhpunitTests(
+				TEST_PLUGIN_CONFIG_PATH,
+				["--filter", "WordPressTest"]
+			);
+
+			// Should only run WordPressTest (3 tests)
+			expect(report.results.summary.tests).toBe(3);
+			expect(report.results.summary.passed).toBe(3);
+
+			// Verify only WordPressTest tests ran
+			const testNames = report.results.tests.map((test) => test.name);
+			expect(testNames.some(name => name.includes("test_can_create_and_retrieve_post"))).toBe(true);
+			expect(testNames.some(name => name.includes("test_sanitize_text_removes_extra_whitespace"))).toBe(false);
+		}
+	);
+
+	it(
+		"should handle mixed flags and file paths",
+		async () => {
+			// Test combining flags with file paths
+			// This simulates: wp-tester test -- --filter test_wordpress tests/WordPressTest.php
+			const report = await runPhpunitTests(
+				TEST_PLUGIN_CONFIG_PATH,
+				["--filter", "test_wordpress", "tests/WordPressTest.php"]
+			);
+
+			// Should only run tests matching filter in the specified file
+			// WordPressTest.php has 3 tests, 2 match "test_wordpress" filter
+			expect(report.results.summary.tests).toBe(2);
+			expect(report.results.summary.passed).toBe(2);
+
+			const testNames = report.results.tests.map((test) => test.name);
+			expect(testNames.some(name => name.includes("test_wordpress_sanitize_functions"))).toBe(true);
+			expect(testNames.some(name => name.includes("test_wordpress_options"))).toBe(true);
+			// This test doesn't match the filter
+			expect(testNames.some(name => name.includes("test_can_create_and_retrieve_post"))).toBe(false);
+		}
+	);
+
+	it(
+		"should handle boolean flags before file paths",
+		async () => {
+			// Test that boolean flags don't prevent path translation
+			// This simulates: wp-tester test -- --stop-on-failure tests/WordPressTest.php
+			const report = await runPhpunitTests(
+				TEST_PLUGIN_CONFIG_PATH,
+				["--stop-on-failure", "tests/WordPressTest.php"]
+			);
+
+			// Should run WordPressTest.php (3 tests)
+			expect(report.results.summary.tests).toBe(3);
+			expect(report.results.summary.passed).toBe(3);
+
+			const testNames = report.results.tests.map((test) => test.name);
+			expect(testNames.some(name => name.includes("test_can_create_and_retrieve_post"))).toBe(true);
+			expect(testNames.some(name => name.includes("test_wordpress_sanitize_functions"))).toBe(true);
+			expect(testNames.some(name => name.includes("test_wordpress_options"))).toBe(true);
+		}
+	);
+
+	it(
+		"should handle path after multiple boolean flags",
+		async () => {
+			// Test path translation after multiple boolean flags
+			// This simulates: wp-tester test -- --no-coverage --stop-on-failure tests/WordPressTest.php
+			const report = await runPhpunitTests(
+				TEST_PLUGIN_CONFIG_PATH,
+				["--no-coverage", "--stop-on-failure", "tests/WordPressTest.php"]
+			);
+
+			// Should run WordPressTest.php (3 tests)
+			expect(report.results.summary.tests).toBe(3);
+			expect(report.results.summary.passed).toBe(3);
+		}
+	);
+
+	it(
+		"should handle flag with equals syntax followed by path",
+		async () => {
+			// Test that = syntax doesn't prevent next path translation
+			// This simulates: wp-tester test -- --colors=auto tests/WordPressTest.php
+			const report = await runPhpunitTests(
+				TEST_PLUGIN_CONFIG_PATH,
+				["--colors=auto", "tests/WordPressTest.php"]
+			);
+
+			// Should run WordPressTest.php (3 tests)
+			expect(report.results.summary.tests).toBe(3);
+			expect(report.results.summary.passed).toBe(3);
+		}
+	);
 });
 
 describe("shouldRunPhpunitTests", () => {

--- a/packages/phpunit/tests/integration/run-phpunit-tests.spec.ts
+++ b/packages/phpunit/tests/integration/run-phpunit-tests.spec.ts
@@ -196,7 +196,7 @@ describe("runPhpunitTests integration", () => {
 	it(
 		"should handle phpunitArgs with flags that have path-like values",
 		async () => {
-			// Test that flag values are NOT translated even if they look like paths
+			// Test that flag values are NOT resolved even if they look like paths
 			// Example: --filter could have a value like "MyNamespace\Tests"
 			const report = await runPhpunitTests(
 				TEST_PLUGIN_CONFIG_PATH,
@@ -240,7 +240,7 @@ describe("runPhpunitTests integration", () => {
 	it(
 		"should handle boolean flags before file paths",
 		async () => {
-			// Test that boolean flags don't prevent path translation
+			// Test that boolean flags don't prevent path resolution
 			// This simulates: wp-tester test -- --stop-on-failure tests/WordPressTest.php
 			const report = await runPhpunitTests(
 				TEST_PLUGIN_CONFIG_PATH,
@@ -261,7 +261,7 @@ describe("runPhpunitTests integration", () => {
 	it(
 		"should handle path after multiple boolean flags",
 		async () => {
-			// Test path translation after multiple boolean flags
+			// Test path resolution after multiple boolean flags
 			// This simulates: wp-tester test -- --no-coverage --stop-on-failure tests/WordPressTest.php
 			const report = await runPhpunitTests(
 				TEST_PLUGIN_CONFIG_PATH,
@@ -277,7 +277,7 @@ describe("runPhpunitTests integration", () => {
 	it(
 		"should handle flag with equals syntax followed by path",
 		async () => {
-			// Test that = syntax doesn't prevent next path translation
+			// Test that = syntax doesn't prevent next path resolution
 			// This simulates: wp-tester test -- --colors=auto tests/WordPressTest.php
 			const report = await runPhpunitTests(
 				TEST_PLUGIN_CONFIG_PATH,

--- a/packages/phpunit/tests/integration/run-phpunit-tests.spec.ts
+++ b/packages/phpunit/tests/integration/run-phpunit-tests.spec.ts
@@ -137,6 +137,61 @@ describe("runPhpunitTests integration", () => {
 			expect(testNames.some(name => name.includes("test_custom_content_filter_is_registered"))).toBe(false);
 		}
 	);
+
+	it(
+		"should run single test file when passed as phpunitArg",
+		async () => {
+			// Test passing a single test file path as an argument
+			// This simulates: wp-tester test -- tests/WordPressTest.php
+			const report = await runPhpunitTests(
+				TEST_PLUGIN_CONFIG_PATH,
+				["tests/WordPressTest.php"]
+			);
+
+			// Validate report structure
+			expect(report).toBeDefined();
+			expect(report.results).toBeDefined();
+			expect(report.results.summary).toBeDefined();
+
+			// Only WordPressTest.php should run (3 tests)
+			// Not UnitTest.php (2 tests)
+			expect(report.results.summary.tests).toBe(3);
+			expect(report.results.summary.passed).toBe(3);
+			expect(report.results.summary.failed).toBe(0);
+
+			// Verify only WordPressTest tests are present
+			const testNames = report.results.tests.map((test) => test.name);
+			expect(testNames.some(name => name.includes("test_can_create_and_retrieve_post"))).toBe(true);
+			expect(testNames.some(name => name.includes("test_wordpress_sanitize_functions"))).toBe(true);
+			expect(testNames.some(name => name.includes("test_wordpress_options"))).toBe(true);
+
+			// UnitTest tests should NOT be present
+			expect(testNames.some(name => name.includes("test_sanitize_text_removes_extra_whitespace"))).toBe(false);
+			expect(testNames.some(name => name.includes("test_custom_content_filter_is_registered"))).toBe(false);
+		}
+	);
+
+	it(
+		"should run tests from directory when passed as phpunitArg",
+		async () => {
+			// Test passing a directory path as an argument
+			// This simulates: wp-tester test -- tests/
+			const report = await runPhpunitTests(
+				TEST_PLUGIN_CONFIG_PATH,
+				["tests/"]
+			);
+
+			// Validate report structure
+			expect(report).toBeDefined();
+			expect(report.results).toBeDefined();
+			expect(report.results.summary).toBeDefined();
+
+			// All tests should run (5 tests total)
+			expect(report.results.summary.tests).toBe(5);
+			expect(report.results.summary.passed).toBe(5);
+			expect(report.results.summary.failed).toBe(0);
+		}
+	);
 });
 
 describe("shouldRunPhpunitTests", () => {


### PR DESCRIPTION
Translate file paths in phpunitArgs from host to VFS paths before
passing to PHPUnit in Playground. Previously, paths like
tests/MyTest.php were passed untranslated, causing PHPUnit to look
in the wrong VFS location.

The fix detects path arguments (file/directory paths vs flags) and
translates them using hostToVfs(), matching the pattern used for
other PHPUnit configuration paths.

- Add path translation logic in runPhpunitTestsForEnvironment
- Handle .php files, directories with/without trailing slash
- Preserve non-path arguments like --filter unchanged
- Add integration tests for single file and directory execution

Fixes #126