### PR TITLE
Improve CLI config prompts with clearer descriptions

### DIFF
--- a/packages/config/src/options/phpunit.ts
+++ b/packages/config/src/options/phpunit.ts
@@ -19,12 +19,12 @@ async function promptForTestMode(): Promise<"unit" | "integration" | null> {
     options: [
       {
         value: "unit",
-        label: "Unit tests (isolated)",
+        label: "Unit tests",
         hint: "Uses WP Test library mocks - won't break existing tests"
       },
       {
         value: "integration",
-        label: "Integration tests (with WordPress)",
+        label: "Integration tests",
         hint: "Runs inside WordPress - call WP functions, test plugin compatibility, make HTTP requests"
       }
     ],

--- a/packages/config/src/options/phpunit.ts
+++ b/packages/config/src/options/phpunit.ts
@@ -20,12 +20,12 @@ async function promptForTestMode(): Promise<"unit" | "integration" | null> {
       {
         value: "unit",
         label: "Unit tests (isolated)",
-        hint: "Recommended if you have existing tests - runs without WordPress loaded"
+        hint: "Uses WP Test library mocks - won't break existing tests"
       },
       {
         value: "integration",
         label: "Integration tests (with WordPress)",
-        hint: "Runs with WordPress loaded - may conflict with existing unit test setup"
+        hint: "Runs inside WordPress - call WP functions, test plugin compatibility, make HTTP requests"
       }
     ],
     initialValue: "unit"

--- a/packages/config/src/options/phpunit.ts
+++ b/packages/config/src/options/phpunit.ts
@@ -19,13 +19,13 @@ async function promptForTestMode(): Promise<"unit" | "integration" | null> {
     options: [
       {
         value: "unit",
-        label: "Unit tests (without WordPress)",
-        hint: "Fast tests for isolated PHP logic, pure functions, classes without WordPress dependencies"
+        label: "Unit tests (isolated)",
+        hint: "Recommended if you have existing tests - runs without WordPress loaded"
       },
       {
         value: "integration",
         label: "Integration tests (with WordPress)",
-        hint: "Tests that interact with WordPress APIs, hooks, database, plugins/themes"
+        hint: "Runs with WordPress loaded - may conflict with existing unit test setup"
       }
     ],
     initialValue: "unit"
@@ -186,11 +186,11 @@ async function handleFullDetection(
 
   // Ask user to confirm or customize
   const action = await clack.select({
-    message: "PHPUnit tests detected. What would you like to do?",
+    message: "PHPUnit configuration detected. What would you like to do?",
     options: [
-      { value: "use", label: "Use detected configuration" },
-      { value: "customize", label: "Customize configuration" },
-      { value: "skip", label: "Skip PHPUnit tests" },
+      { value: "use", label: "Use detected configuration", hint: "Recommended" },
+      { value: "customize", label: "Customize configuration", hint: "Specify different paths" },
+      { value: "skip", label: "Skip PHPUnit tests", hint: "Configure later" },
     ],
     initialValue: "use",
   });
@@ -258,9 +258,9 @@ async function handlePartialDetection(
     const action = await clack.select({
       message: "What would you like to do?",
       options: [
-        { value: "retry", label: "I've installed it, try again" },
-        { value: "custom", label: "Specify custom path" },
-        { value: "skip", label: "Skip for now" },
+        { value: "retry", label: "Try again", hint: "After running composer install" },
+        { value: "custom", label: "Specify custom path", hint: "PHPUnit is in a different location" },
+        { value: "skip", label: "Skip for now", hint: "Configure later" },
       ],
       initialValue: "retry",
     });

--- a/packages/config/src/options/project-type.ts
+++ b/packages/config/src/options/project-type.ts
@@ -39,9 +39,9 @@ export async function projectTypeOption(
     const selectedType = await clack.select({
       message: "Select project type:",
       options: [
-        { value: 'plugin', label: 'Plugin', hint: 'Mounted to wp-content/plugins/' },
-        { value: 'theme', label: 'Theme', hint: 'Mounted to wp-content/themes/' },
-        { value: 'other', label: 'Other', hint: 'Custom mount path' },
+        { value: 'plugin', label: 'Plugin' },
+        { value: 'theme', label: 'Theme' },
+        { value: 'other', label: 'Other' },
       ],
     });
 

--- a/packages/config/src/options/project-type.ts
+++ b/packages/config/src/options/project-type.ts
@@ -39,9 +39,9 @@ export async function projectTypeOption(
     const selectedType = await clack.select({
       message: "Select project type:",
       options: [
-        { value: 'plugin', label: 'plugin' },
-        { value: 'theme', label: 'theme' },
-        { value: 'other', label: 'other' },
+        { value: 'plugin', label: 'Plugin', hint: 'Mounted to wp-content/plugins/' },
+        { value: 'theme', label: 'Theme', hint: 'Mounted to wp-content/themes/' },
+        { value: 'other', label: 'Other', hint: 'Custom mount path' },
       ],
     });
 

--- a/packages/config/src/options/smoke-tests.ts
+++ b/packages/config/src/options/smoke-tests.ts
@@ -23,7 +23,7 @@ export async function smokeTestsOption(
 
   // Ask about WordPress smoke tests
   const runWpTests = await clack.confirm({
-    message: "Run WordPress boot test? (Verifies WordPress loads with your code)",
+    message: "Run WordPress smoke tests? (Verifies WordPress doesn't crash with your code)",
     initialValue: true,
   });
 
@@ -39,7 +39,7 @@ export async function smokeTestsOption(
   // Ask about plugin tests if project type is plugin
   if (config.projectType === 'plugin') {
     const runPluginTests = await clack.confirm({
-      message: "Run plugin activation test? (Verifies your plugin activates without errors)",
+      message: "Run plugin smoke tests? (Verifies your plugin doesn't crash on activation)",
       initialValue: true,
     });
 
@@ -67,7 +67,7 @@ export async function smokeTestsOption(
   // Ask about theme tests if project type is theme
   if (config.projectType === 'theme') {
     const runThemeTests = await clack.confirm({
-      message: "Run theme activation test? (Verifies your theme activates without errors)",
+      message: "Run theme smoke tests? (Verifies your theme doesn't crash on activation)",
       initialValue: true,
     });
 

--- a/packages/config/src/options/smoke-tests.ts
+++ b/packages/config/src/options/smoke-tests.ts
@@ -22,8 +22,12 @@ export async function smokeTestsOption(
   const defaultSlug = projectHostPath.split('/').pop() || '';
 
   // Ask about WordPress smoke tests
-  const runWpTests = await clack.confirm({
-    message: "Run WordPress smoke tests? (Verifies WordPress doesn't crash with your code)",
+  const runWpTests = await clack.select({
+    message: "Run WordPress smoke tests?",
+    options: [
+      { value: true, label: "Yes", hint: "Verifies WordPress doesn't crash with your code" },
+      { value: false, label: "No" },
+    ],
     initialValue: true,
   });
 
@@ -38,8 +42,12 @@ export async function smokeTestsOption(
 
   // Ask about plugin tests if project type is plugin
   if (config.projectType === 'plugin') {
-    const runPluginTests = await clack.confirm({
-      message: "Run plugin smoke tests? (Verifies your plugin doesn't crash on activation)",
+    const runPluginTests = await clack.select({
+      message: "Run plugin smoke tests?",
+      options: [
+        { value: true, label: "Yes", hint: "Verifies your plugin doesn't crash on activation" },
+        { value: false, label: "No" },
+      ],
       initialValue: true,
     });
 
@@ -66,8 +74,12 @@ export async function smokeTestsOption(
 
   // Ask about theme tests if project type is theme
   if (config.projectType === 'theme') {
-    const runThemeTests = await clack.confirm({
-      message: "Run theme smoke tests? (Verifies your theme doesn't crash on activation)",
+    const runThemeTests = await clack.select({
+      message: "Run theme smoke tests?",
+      options: [
+        { value: true, label: "Yes", hint: "Verifies your theme doesn't crash on activation" },
+        { value: false, label: "No" },
+      ],
       initialValue: true,
     });
 

--- a/packages/config/src/options/smoke-tests.ts
+++ b/packages/config/src/options/smoke-tests.ts
@@ -23,7 +23,7 @@ export async function smokeTestsOption(
 
   // Ask about WordPress smoke tests
   const runWpTests = await clack.confirm({
-    message: "Do you want to run WordPress smoke tests?",
+    message: "Run WordPress boot test? (Verifies WordPress loads with your code)",
     initialValue: true,
   });
 
@@ -39,7 +39,7 @@ export async function smokeTestsOption(
   // Ask about plugin tests if project type is plugin
   if (config.projectType === 'plugin') {
     const runPluginTests = await clack.confirm({
-      message: "Do you want to run Plugin smoke tests?",
+      message: "Run plugin activation test? (Verifies your plugin activates without errors)",
       initialValue: true,
     });
 
@@ -67,7 +67,7 @@ export async function smokeTestsOption(
   // Ask about theme tests if project type is theme
   if (config.projectType === 'theme') {
     const runThemeTests = await clack.confirm({
-      message: "Do you want to run Theme smoke tests?",
+      message: "Run theme activation test? (Verifies your theme activates without errors)",
       initialValue: true,
     });
 


### PR DESCRIPTION
Add descriptive hints to setup prompts for smoke tests and PHPUnit test types.

Fixes #128, #129, #130