### PR TITLE
Add configuration summary to config validate command

### DIFF
--- a/packages/cli/src/commands/config/index.ts
+++ b/packages/cli/src/commands/config/index.ts
@@ -1,7 +1,7 @@
 import { optionNames, type OptionName } from '@wp-tester/config';
 import { updateConfigOption } from './option';
 import * as clack from '../../cli/theme';
-import { validateConfig } from './validate';
+import { validateConfig, generateConfigSummary, printConfigSummary } from './validate';
 import pc from 'picocolors';
 
 interface ConfigArgs {
@@ -13,11 +13,15 @@ export const configHandler = async (argv: ConfigArgs): Promise<void> => {
   const { action, config } = argv;
 
   if (action === "validate") {
-    const isValid = await validateConfig(config);
-    if (!isValid) {
+    const validatedConfig = await validateConfig(config);
+    if (!validatedConfig) {
       process.exit(1);
     }
     console.log(pc.green(pc.bold("✓ Configuration is valid")));
+
+    // Display configuration summary
+    const summary = generateConfigSummary(validatedConfig);
+    printConfigSummary(summary);
   } else if (action && optionNames.includes(action as OptionName)) {
     await updateConfigOption(action as OptionName);
   } else {

--- a/packages/cli/src/commands/config/validate.ts
+++ b/packages/cli/src/commands/config/validate.ts
@@ -1,8 +1,96 @@
 import { readFile } from 'fs/promises';
 import Ajv, { type ErrorObject } from "ajv";
 import pc from "picocolors";
-import { getSchemaPath, normalizeConfigPath, type WPTesterConfig } from "@wp-tester/config";
+import { getSchemaPath, normalizeConfigPath, type WPTesterConfig, type Tests } from "@wp-tester/config";
 import * as clack from "../../cli/theme";
+
+/**
+ * Summary of enabled test suites
+ */
+export interface TestSuiteSummary {
+  name: string;
+  label: string;
+}
+
+/**
+ * Configuration summary for display
+ */
+export interface ConfigSummary {
+  activeEnvironments: number;
+  skippedEnvironments: number;
+  testSuites: TestSuiteSummary[];
+  matrixCombinations: number;
+}
+
+/**
+ * Get a list of enabled test suites from the tests configuration
+ */
+export function getEnabledTestSuites(tests: Tests): TestSuiteSummary[] {
+  const suites: TestSuiteSummary[] = [];
+
+  if (tests.wp) {
+    suites.push({ name: 'wp', label: 'WordPress' });
+  }
+
+  if (tests.plugin) {
+    suites.push({ name: 'plugin', label: `Plugin (${tests.plugin})` });
+  }
+
+  if (tests.theme) {
+    suites.push({ name: 'theme', label: `Theme (${tests.theme})` });
+  }
+
+  if (tests.phpunit) {
+    const modeLabel = tests.phpunit.testMode === 'integration' ? 'integration' : 'unit';
+    suites.push({ name: 'phpunit', label: `PHPUnit (${modeLabel})` });
+  }
+
+  return suites;
+}
+
+/**
+ * Generate a configuration summary from a valid config
+ */
+export function generateConfigSummary(config: WPTesterConfig): ConfigSummary {
+  const activeEnvironments = config.environments.filter(env => !env.skip).length;
+  const skippedEnvironments = config.environments.filter(env => env.skip).length;
+  const testSuites = getEnabledTestSuites(config.tests);
+  const matrixCombinations = activeEnvironments * testSuites.length;
+
+  return {
+    activeEnvironments,
+    skippedEnvironments,
+    testSuites,
+    matrixCombinations,
+  };
+}
+
+/**
+ * Print the configuration summary
+ */
+export function printConfigSummary(summary: ConfigSummary): void {
+  console.log();
+  console.log(pc.bold('Configuration Summary'));
+  console.log();
+
+  // Environment count
+  if (summary.skippedEnvironments > 0) {
+    console.log(`  Environments: ${pc.cyan(String(summary.activeEnvironments))} active, ${pc.yellow(String(summary.skippedEnvironments))} skipped`);
+  } else {
+    console.log(`  Environments: ${pc.cyan(String(summary.activeEnvironments))}`);
+  }
+
+  // Test suites
+  if (summary.testSuites.length > 0) {
+    const suiteLabels = summary.testSuites.map(s => s.label).join(', ');
+    console.log(`  Test suites:  ${pc.cyan(suiteLabels)}`);
+  } else {
+    console.log(`  Test suites:  ${pc.dim('None configured')}`);
+  }
+
+  // Matrix combinations
+  console.log(`  Total runs:   ${pc.cyan(String(summary.matrixCombinations))}`);
+}
 
 interface ValidationErrorDisplay {
   message: string;
@@ -109,9 +197,9 @@ export function formatValidationError(error: ErrorObject): ValidationErrorDispla
 
 /**
  * Validates config and prints errors if invalid.
- * Returns true if valid, false otherwise.
+ * Returns the validated config if valid, null otherwise.
  */
-export async function validateConfig(configPath: string): Promise<boolean> {
+export async function validateConfig(configPath: string): Promise<WPTesterConfig | null> {
   try {
     // Resolve config path relative to cwd and normalize (handles directory paths)
     const resolvedConfigPath = normalizeConfigPath(configPath);
@@ -155,7 +243,7 @@ export async function validateConfig(configPath: string): Promise<boolean> {
         }
       }
 
-      return false;
+      return null;
     }
 
     // Check for skipped environments and display info
@@ -170,11 +258,11 @@ export async function validateConfig(configPath: string): Promise<boolean> {
       }
     }
 
-    return true;
+    return typedConfig;
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
     clack.log.error("Validation error:");
     clack.log.error(message);
-    return false;
+    return null;
   }
 }

--- a/packages/cli/src/commands/config/validate.ts
+++ b/packages/cli/src/commands/config/validate.ts
@@ -69,27 +69,27 @@ export function generateConfigSummary(config: WPTesterConfig): ConfigSummary {
  * Print the configuration summary
  */
 export function printConfigSummary(summary: ConfigSummary): void {
-  console.log();
-  console.log(pc.bold('Configuration Summary'));
-  console.log();
+  const lines: string[] = [];
 
   // Environment count
   if (summary.skippedEnvironments > 0) {
-    console.log(`  Environments: ${pc.cyan(String(summary.activeEnvironments))} active, ${pc.yellow(String(summary.skippedEnvironments))} skipped`);
+    lines.push(`Environments: ${pc.cyan(String(summary.activeEnvironments))} active, ${pc.yellow(String(summary.skippedEnvironments))} skipped`);
   } else {
-    console.log(`  Environments: ${pc.cyan(String(summary.activeEnvironments))}`);
+    lines.push(`Environments: ${pc.cyan(String(summary.activeEnvironments))}`);
   }
 
   // Test suites
   if (summary.testSuites.length > 0) {
     const suiteLabels = summary.testSuites.map(s => s.label).join(', ');
-    console.log(`  Test suites:  ${pc.cyan(suiteLabels)}`);
+    lines.push(`Test suites:  ${pc.cyan(suiteLabels)}`);
   } else {
-    console.log(`  Test suites:  ${pc.dim('None configured')}`);
+    lines.push(`Test suites:  ${pc.dim('None configured')}`);
   }
 
   // Matrix combinations
-  console.log(`  Total runs:   ${pc.cyan(String(summary.matrixCombinations))}`);
+  lines.push(`Total runs:   ${pc.cyan(String(summary.matrixCombinations))}`);
+
+  clack.note(lines.join('\n'), 'Configuration Summary');
 }
 
 interface ValidationErrorDisplay {

--- a/packages/cli/tests/integration/cli.spec.ts
+++ b/packages/cli/tests/integration/cli.spec.ts
@@ -32,4 +32,16 @@ describe('CLI Integration Tests', () => {
     });
     expect(output).toContain('Configuration is valid');
   });
+
+  it('should show configuration summary after validation', () => {
+    const fixtureConfig = join(__dirname, '../fixtures/wp-tester.json');
+    const output = execSync(`node ${cliPath} config validate -c ${fixtureConfig}`, {
+      encoding: 'utf-8',
+      cwd: join(__dirname, '../../../..'),
+    });
+    expect(output).toContain('Configuration Summary');
+    expect(output).toContain('Environments:');
+    expect(output).toContain('Test suites:');
+    expect(output).toContain('Total runs:');
+  });
 });

--- a/packages/cli/tests/validate.spec.ts
+++ b/packages/cli/tests/validate.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { type ErrorObject } from 'ajv';
-import { formatValidationError } from '../src/commands/config/validate';
+import { formatValidationError, getEnabledTestSuites, generateConfigSummary } from '../src/commands/config/validate';
+import type { Tests, WPTesterConfig } from '@wp-tester/config';
 
 describe('formatValidationError', () => {
   it('should format additionalProperties error', () => {
@@ -122,5 +123,123 @@ describe('formatValidationError', () => {
     expect(result.message).toContain('/someField');
     expect(result.message).toContain('must match pattern');
     expect(result.docsUrl).toBe('https://bgrgicak.github.io/wp-tester/#/configuration');
+  });
+});
+
+describe('getEnabledTestSuites', () => {
+  it('should return empty array when no tests are enabled', () => {
+    const tests: Tests = {};
+    const result = getEnabledTestSuites(tests);
+    expect(result).toEqual([]);
+  });
+
+  it('should include WordPress tests when wp is true', () => {
+    const tests: Tests = { wp: true };
+    const result = getEnabledTestSuites(tests);
+    expect(result).toContainEqual({ name: 'wp', label: 'WordPress' });
+  });
+
+  it('should include plugin tests with plugin name', () => {
+    const tests: Tests = { plugin: 'my-plugin' };
+    const result = getEnabledTestSuites(tests);
+    expect(result).toContainEqual({ name: 'plugin', label: 'Plugin (my-plugin)' });
+  });
+
+  it('should include theme tests with theme name', () => {
+    const tests: Tests = { theme: 'my-theme' };
+    const result = getEnabledTestSuites(tests);
+    expect(result).toContainEqual({ name: 'theme', label: 'Theme (my-theme)' });
+  });
+
+  it('should include PHPUnit tests with unit mode by default', () => {
+    const tests: Tests = { phpunit: { phpunitPath: 'vendor/bin/phpunit', configPath: 'phpunit.xml' } };
+    const result = getEnabledTestSuites(tests);
+    expect(result).toContainEqual({ name: 'phpunit', label: 'PHPUnit (unit)' });
+  });
+
+  it('should include PHPUnit tests with integration mode', () => {
+    const tests: Tests = { phpunit: { phpunitPath: 'vendor/bin/phpunit', configPath: 'phpunit.xml', testMode: 'integration' } };
+    const result = getEnabledTestSuites(tests);
+    expect(result).toContainEqual({ name: 'phpunit', label: 'PHPUnit (integration)' });
+  });
+
+  it('should include all enabled test suites', () => {
+    const tests: Tests = {
+      wp: true,
+      plugin: 'my-plugin',
+      phpunit: { phpunitPath: 'vendor/bin/phpunit', configPath: 'phpunit.xml', testMode: 'integration' }
+    };
+    const result = getEnabledTestSuites(tests);
+    expect(result).toHaveLength(3);
+    expect(result.map(s => s.name)).toEqual(['wp', 'plugin', 'phpunit']);
+  });
+});
+
+describe('generateConfigSummary', () => {
+  const baseBlueprint = { preferredVersions: { php: 'latest', wp: 'latest' } };
+
+  it('should count active environments', () => {
+    const config: WPTesterConfig = {
+      environments: [
+        { name: 'Env 1', blueprint: baseBlueprint },
+        { name: 'Env 2', blueprint: baseBlueprint },
+      ],
+      tests: { wp: true }
+    };
+    const result = generateConfigSummary(config);
+    expect(result.activeEnvironments).toBe(2);
+    expect(result.skippedEnvironments).toBe(0);
+  });
+
+  it('should count skipped environments separately', () => {
+    const config: WPTesterConfig = {
+      environments: [
+        { name: 'Env 1', blueprint: baseBlueprint },
+        { name: 'Env 2', blueprint: baseBlueprint, skip: true },
+        { name: 'Env 3', blueprint: baseBlueprint, skip: true },
+      ],
+      tests: { wp: true }
+    };
+    const result = generateConfigSummary(config);
+    expect(result.activeEnvironments).toBe(1);
+    expect(result.skippedEnvironments).toBe(2);
+  });
+
+  it('should calculate matrix combinations correctly', () => {
+    const config: WPTesterConfig = {
+      environments: [
+        { name: 'Env 1', blueprint: baseBlueprint },
+        { name: 'Env 2', blueprint: baseBlueprint },
+        { name: 'Env 3', blueprint: baseBlueprint },
+      ],
+      tests: { wp: true, plugin: 'my-plugin' }
+    };
+    const result = generateConfigSummary(config);
+    // 3 environments * 2 test suites = 6 combinations
+    expect(result.matrixCombinations).toBe(6);
+  });
+
+  it('should exclude skipped environments from matrix calculation', () => {
+    const config: WPTesterConfig = {
+      environments: [
+        { name: 'Env 1', blueprint: baseBlueprint },
+        { name: 'Env 2', blueprint: baseBlueprint, skip: true },
+      ],
+      tests: { wp: true, plugin: 'my-plugin' }
+    };
+    const result = generateConfigSummary(config);
+    // 1 active environment * 2 test suites = 2 combinations
+    expect(result.matrixCombinations).toBe(2);
+  });
+
+  it('should return zero matrix combinations when no test suites', () => {
+    const config: WPTesterConfig = {
+      environments: [
+        { name: 'Env 1', blueprint: baseBlueprint },
+      ],
+      tests: {}
+    };
+    const result = generateConfigSummary(config);
+    expect(result.matrixCombinations).toBe(0);
   });
 });

--- a/packages/cli/tests/validate.spec.ts
+++ b/packages/cli/tests/validate.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { type ErrorObject } from 'ajv';
 import { formatValidationError, getEnabledTestSuites, generateConfigSummary } from '../src/commands/config/validate';
 import type { Tests, WPTesterConfig } from '@wp-tester/config';
+import { Blueprint } from "@wp-playground/blueprints";
 
 describe('formatValidationError', () => {
   it('should format additionalProperties error', () => {
@@ -136,31 +137,31 @@ describe('getEnabledTestSuites', () => {
   it('should include WordPress tests when wp is true', () => {
     const tests: Tests = { wp: true };
     const result = getEnabledTestSuites(tests);
-    expect(result).toContainEqual({ name: 'wp', label: 'WordPress' });
+    expect(result.map((s) => s.name)).toContain("wp");
   });
 
   it('should include plugin tests with plugin name', () => {
     const tests: Tests = { plugin: 'my-plugin' };
     const result = getEnabledTestSuites(tests);
-    expect(result).toContainEqual({ name: 'plugin', label: 'Plugin (my-plugin)' });
+    expect(result.map((s) => s.name)).toContain("plugin");
   });
 
   it('should include theme tests with theme name', () => {
     const tests: Tests = { theme: 'my-theme' };
     const result = getEnabledTestSuites(tests);
-    expect(result).toContainEqual({ name: 'theme', label: 'Theme (my-theme)' });
+    expect(result.map((s) => s.name)).toContain("theme");
   });
 
   it('should include PHPUnit tests with unit mode by default', () => {
     const tests: Tests = { phpunit: { phpunitPath: 'vendor/bin/phpunit', configPath: 'phpunit.xml' } };
     const result = getEnabledTestSuites(tests);
-    expect(result).toContainEqual({ name: 'phpunit', label: 'PHPUnit (unit)' });
+    expect(result.map((s) => s.name)).toContain("phpunit");
   });
 
   it('should include PHPUnit tests with integration mode', () => {
     const tests: Tests = { phpunit: { phpunitPath: 'vendor/bin/phpunit', configPath: 'phpunit.xml', testMode: 'integration' } };
     const result = getEnabledTestSuites(tests);
-    expect(result).toContainEqual({ name: 'phpunit', label: 'PHPUnit (integration)' });
+    expect(result.map((s) => s.name)).toContain("phpunit");
   });
 
   it('should include all enabled test suites', () => {
@@ -176,7 +177,9 @@ describe('getEnabledTestSuites', () => {
 });
 
 describe('generateConfigSummary', () => {
-  const baseBlueprint = { preferredVersions: { php: 'latest', wp: 'latest' } };
+  const baseBlueprint: Blueprint = {
+    preferredVersions: { php: "latest", wp: "latest" },
+  };
 
   it('should count active environments', () => {
     const config: WPTesterConfig = {


### PR DESCRIPTION
Display a summary after successful validation including:
- Environment count (active and skipped)
- Test suite summary with types and names
- Total matrix combinations (environments × test suites)

Closes #136