### PR TITLE
Improve test error output formatting for PHPUnit and Smoke tests

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -426,6 +426,8 @@ Integration test mode runs your tests with the full WordPress environment loaded
 
 **When to use:** When your tests need WordPress functions, database access, or any WordPress-specific functionality.
 
+**How it works:** In integration mode, wp-tester automatically loads WordPress before your bootstrap file runs. Your bootstrap only needs to handle unit mode setup.
+
 ##### Default Behavior
 
 If you omit the `testMode` property, it defaults to `"unit"`:
@@ -466,18 +468,24 @@ When you run PHPUnit unit tests, WP Tester automatically:
 4. Generates `wp-tests-config.php` with proper database and path settings
 5. Sets the `WP_TESTS_DIR` environment variable
 
-**Your test bootstrap** should reference wordpress-tests-lib normally:
+**Your test bootstrap** only needs to handle unit mode (integration mode is handled by wp-tester):
 
 ```php
 <?php
+// Check for unit mode (WordPress test library)
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 
-if ( ! $_tests_dir ) {
-    $_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
-}
+if ( $_tests_dir && file_exists( $_tests_dir . '/includes/functions.php' ) ) {
+    // Unit mode: Load WordPress test library
+    require_once $_tests_dir . '/includes/functions.php';
 
-require_once $_tests_dir . '/includes/functions.php';
-require $_tests_dir . '/includes/bootstrap.php';
+    tests_add_filter( 'muplugins_loaded', function() {
+        require dirname( __DIR__ ) . '/your-plugin.php';
+    } );
+
+    require $_tests_dir . '/includes/bootstrap.php';
+}
+// Note: Integration mode doesn't need bootstrap code - wp-tester loads WordPress automatically
 ```
 
 **Why unit tests only?**

--- a/packages/cli/src/commands/test/index.ts
+++ b/packages/cli/src/commands/test/index.ts
@@ -2,19 +2,27 @@ import { runTests, executeTests } from './runner';
 import { runWatchMode } from './watcher';
 import type { TestType } from '@wp-tester/config';
 import { getWorkingDirectory } from '@wp-tester/config';
-import path from 'path';
+import * as clack from "@clack/prompts";
+import path from "path";
 
 interface TestArgs {
   config?: string;
   test?: TestType;
   watch?: boolean;
   passWithNoTests?: boolean;
-  '--'?: string[];
+  "--"?: string[];
 }
 
 export const testHandler = async (argv: TestArgs): Promise<void> => {
-  const { config = './wp-tester.json', test, watch, passWithNoTests } = argv;
-  const phpunitArgs = argv['--'] || [];
+  const { config = "./wp-tester.json", test, watch, passWithNoTests } = argv;
+  const extraArgs = argv["--"] || [];
+
+  if (extraArgs.length > 0 && test === undefined) {
+    clack.log.error(
+      "You provided extra arguments but didn't specify which tests to run.\n\nExtra arguments are passed to the test runner, so we need to know whether to pass them to PHPUnit or Smoke tests.\n\nPlease use --test to specify the test type."
+    );
+    process.exit(1);
+  }
 
   if (watch) {
     const cwd = getWorkingDirectory();
@@ -22,11 +30,19 @@ export const testHandler = async (argv: TestArgs): Promise<void> => {
     await runWatchMode({
       configPath: absoluteConfigPath,
       onRunTests: async () => {
-        await executeTests(absoluteConfigPath, { testType: test, phpunitArgs, passWithNoTests });
+        await executeTests(absoluteConfigPath, {
+          testType: test,
+          extraArgs,
+          passWithNoTests,
+        });
       },
     });
   } else {
-    await runTests(config, { testType: test, phpunitArgs, passWithNoTests });
+    await runTests(config, {
+      testType: test,
+      extraArgs,
+      passWithNoTests,
+    });
   }
 };
 

--- a/packages/cli/src/commands/test/runner.ts
+++ b/packages/cli/src/commands/test/runner.ts
@@ -14,8 +14,8 @@ import { getWorkingDirectory } from '@wp-tester/config';
 export interface RunTestsOptions {
   /** Type of test to run (phpunit, wp, plugin, theme) */
   testType?: TestType;
-  /** Additional arguments to pass to PHPUnit */
-  phpunitArgs?: string[];
+  /** Additional arguments to pass to test runners */
+  extraArgs?: string[];
   /** Allow the test suite to pass when no tests are executed (CLI override) */
   passWithNoTests?: boolean;
 }
@@ -76,7 +76,7 @@ export const executeTests = async (
   configPath: string,
   options?: RunTestsOptions
 ): Promise<TestResult> => {
-  const { testType, phpunitArgs } = options || {};
+  const { testType, extraArgs } = options || {};
   const finalConfigPath = await resolveConfigPath(configPath);
 
   // Validate configuration before running tests
@@ -96,7 +96,8 @@ export const executeTests = async (
   if (smokeTestFilter !== false) {
     const smokeTestReport = await runSmokeTests(
       finalConfigPath,
-      smokeTestFilter
+      smokeTestFilter,
+      extraArgs
     );
     if (smokeTestReport.results.summary.tests > 0) {
       reports.push(smokeTestReport);
@@ -105,7 +106,7 @@ export const executeTests = async (
 
   // Run PHPUnit tests
   if (shouldRunPhpUnit) {
-    const phpunitReport = await runPhpunitTests(finalConfigPath, phpunitArgs);
+    const phpunitReport = await runPhpunitTests(finalConfigPath, extraArgs);
     // Always include report if PHPUnit was configured to run
     // This ensures bootstrap failures are visible
     if (phpunitReport.results.summary.tests > 0) {

--- a/packages/cli/src/commands/test/runner.ts
+++ b/packages/cli/src/commands/test/runner.ts
@@ -146,7 +146,7 @@ export const runTests = async (
   configPath: string,
   options?: RunTestsOptions
 ): Promise<void> => {
-  const { testType, phpunitArgs, passWithNoTests } = options || {};
+  const { passWithNoTests } = options || {};
   let finalConfigPath = await resolveConfigPath(configPath);
 
   // Check if config file exists
@@ -174,75 +174,16 @@ export const runTests = async (
   const result = await executeTests(finalConfigPath, options);
 
   if (!result.hasTests) {
-    process.exit(1);
-  }
-
-  // Run all test suites and collect results
-  const reports: Report[] = [];
-
-  // Determine which tests to run based on testType parameter
-  const shouldRunPhpUnit = !testType || testType === "phpunit";
-
-  // Run smoke tests (wp, plugin, theme) - smoke tests package handles whether to run
-  const smokeTestFilter = getSmokeTestFilter(testType);
-  const smokeTestReport = await runSmokeTests(
-    finalConfigPath,
-    smokeTestFilter
-  );
-  if (smokeTestReport.results.summary.tests > 0) {
-    reports.push(smokeTestReport);
-  }
-
-  // Run PHPUnit tests
-  if (shouldRunPhpUnit) {
-    const phpunitReport = await runPhpunitTests(finalConfigPath, phpunitArgs);
-    // Include report only if it has tests
-    if (phpunitReport.results.summary.tests > 0) {
-      reports.push(phpunitReport);
-    }
-  }
-
-  // Merge all reports
-  if (reports.length === 0) {
     // If passWithNoTests is enabled, treat no tests as success
     if (passWithNoTests) {
       clack.log.info("No tests were run. Check your configuration.");
       process.exit(0);
     }
-    clack.log.error("No tests were run. Check your configuration.");
     process.exit(1);
   }
-
-  // Merge results from all test suites
-  const mergedReport = mergeReports(reports);
-
-  // Display unified summary
-  const { summary, tests } = mergedReport.results;
-
-  // Print failed test details
-  const failedTests = tests.filter(test => test.status === 'failed');
-  if (failedTests.length > 0) {
-    for (const test of failedTests) {
-      if (test.trace) {
-        console.error(`\n${test.name}:\n${test.trace}`);
-      }
-    }
-  }
-
-  // Print final combined summary
-  printSummary(summary);
 
   // Determine exit code based on test results
-  const hasFailures = summary.failed > 0;
-  const noTestsExecuted = summary.tests === 0;
-
-  if (hasFailures) {
-    process.exit(1);
-  }
-
-  // If no tests were executed, exit with code 1 unless passWithNoTests is enabled
-  if (noTestsExecuted && !passWithNoTests) {
-    clack.log.warn("No tests were executed. Use --passWithNoTests to allow this to pass.");
+  if (!result.success) {
     process.exit(1);
   }
 

--- a/packages/cli/src/commands/test/runner.ts
+++ b/packages/cli/src/commands/test/runner.ts
@@ -123,18 +123,8 @@ export const executeTests = async (
   const mergedReport = mergeReports(reports);
 
   // Display unified summary
-  const { summary, tests } = mergedReport.results;
+  const { summary } = mergedReport.results;
   const success = summary.failed === 0;
-
-  // Print failed test details
-  const failedTests = tests.filter(test => test.status === 'failed');
-  if (failedTests.length > 0) {
-    for (const test of failedTests) {
-      if (test.trace) {
-        console.error(`\n${test.name}:\n${test.trace}`);
-      }
-    }
-  }
 
   // Print final combined summary
   printSummary(summary);

--- a/packages/cli/tests/integration/cli.spec.ts
+++ b/packages/cli/tests/integration/cli.spec.ts
@@ -2,11 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { execSync } from 'child_process';
 import { join } from 'path';
 
-const cliPath = join(__dirname, '../../dist/cli/cli.js');
+const cliPath = join(__dirname, '../../src/cli/cli.ts');
+const cliCommand = `npx tsx ${cliPath}`;
 
-describe('CLI Integration Tests', () => {
+describe('CLI Integration Tests', { timeout: 30000 }, () => {
   it('should show help', () => {
-    const output = execSync(`node ${cliPath} --help`, { encoding: 'utf-8' });
+    const output = execSync(`${cliCommand} --help`, { encoding: 'utf-8' });
     expect(output).toContain('wp-tester <command> [options]');
     expect(output).toContain('Commands:');
     expect(output).toContain('setup');
@@ -15,18 +16,18 @@ describe('CLI Integration Tests', () => {
   });
 
   it('should show version', () => {
-    const output = execSync(`node ${cliPath} --version`, { encoding: 'utf-8' });
+    const output = execSync(`${cliCommand} --version`, { encoding: 'utf-8' });
     expect(output.trim()).toMatch(/^\d+\.\d+\.\d+$/);
   });
 
   it('should show config help', () => {
-    const output = execSync(`node ${cliPath} config --help`, { encoding: 'utf-8' });
+    const output = execSync(`${cliCommand} config --help`, { encoding: 'utf-8' });
     expect(output).toContain('Manage wp-tester configuration');
   });
 
   it('should validate config successfully', () => {
     const fixtureConfig = join(__dirname, '../fixtures/wp-tester.json');
-    const output = execSync(`node ${cliPath} config validate -c ${fixtureConfig}`, {
+    const output = execSync(`${cliCommand} config validate -c ${fixtureConfig}`, {
       encoding: 'utf-8',
       cwd: join(__dirname, '../../../..'),
     });
@@ -35,7 +36,7 @@ describe('CLI Integration Tests', () => {
 
   it('should show configuration summary after validation', () => {
     const fixtureConfig = join(__dirname, '../fixtures/wp-tester.json');
-    const output = execSync(`node ${cliPath} config validate -c ${fixtureConfig}`, {
+    const output = execSync(`${cliCommand} config validate -c ${fixtureConfig}`, {
       encoding: 'utf-8',
       cwd: join(__dirname, '../../../..'),
     });

--- a/packages/phpunit/src/runner.ts
+++ b/packages/phpunit/src/runner.ts
@@ -185,22 +185,12 @@ async function runPhpunitTestsForEnvironment(
           write(chunk) {
             const text = stderrDecoder.decode(chunk, { stream: true });
             stderrCapture += text;
-            // Try to parse as TeamCity format first
-            parser.write(text);
 
-            // If streaming is disabled, also write non-TeamCity lines to stderr
+            // If streaming is disabled, write stderr to console
             // This ensures error messages still appear
             if (!useStreaming) {
-              const lines = text.split("\n");
-              for (const line of lines) {
-                if (!line.trim().startsWith("##teamcity[")) {
-                  process.stderr.write(line + "\n");
-                }
-              }
+              process.stderr.write(text);
             }
-          },
-          close() {
-            parser.flush();
           },
         })
       ),

--- a/packages/phpunit/src/runner.ts
+++ b/packages/phpunit/src/runner.ts
@@ -10,7 +10,7 @@ import {
   resolveAbsolute,
 } from "@wp-tester/config";
 import type { Report } from "@wp-tester/results";
-import { EMPTY_REPORT, mergeReports, StreamingReporter, TeamCityParser } from "@wp-tester/results";
+import { EMPTY_REPORT, mergeReports, PHPUnitStreamingReporter, TeamCityParser } from "@wp-tester/results";
 import { startPlayground } from "@wp-tester/runtime";
 import { mountWordPressTestLibrary } from "./wordpress-test-lib";
 import { access } from "fs/promises";
@@ -137,7 +137,7 @@ async function runPhpunitTestsForEnvironment(
     // Create streaming reporter
     // Disable summary since the CLI will print a combined summary
     const useStreaming = config.reporters?.includes("default") ?? true;
-    const reporter = new StreamingReporter({
+    const reporter = new PHPUnitStreamingReporter({
       enabled: useStreaming,
       showSummary: false,
     });

--- a/packages/phpunit/tests/unit/teamcity-parser.spec.ts
+++ b/packages/phpunit/tests/unit/teamcity-parser.spec.ts
@@ -57,6 +57,33 @@ describe("TeamCityParser", () => {
       expect(events[3]).toEqual({ type: "suite:end", name: "TestClass" });
     });
 
+    it("should parse a comparison failure and format the diff", () => {
+      const output = `
+##teamcity[testSuiteStarted name='TestClass']
+##teamcity[testStarted name='testMethod']
+##teamcity[testFailed name='testMethod' message='Failed asserting that two strings are equal.' details='/path/to/file.php:42' type='comparisonFailure' actual='|'Hello World|'' expected='|'Hello World Test|'']
+##teamcity[testFinished name='testMethod' duration='50']
+##teamcity[testSuiteFinished name='TestClass']
+`;
+      const events = parseTeamCityOutput(output);
+
+      expect(events).toHaveLength(4);
+      expect(events[2]).toMatchObject({
+        type: "test:fail",
+        name: "testMethod",
+        suiteName: "TestClass",
+        message: "Failed asserting that two strings are equal.",
+      });
+
+      // Verify the trace includes the formatted diff with highlighting markers
+      const failEvent = events[2] as { trace?: string };
+      expect(failEvent.trace).toContain("Expected:");
+      expect(failEvent.trace).toContain("'Hello World« Test»'");
+      expect(failEvent.trace).toContain("Actual:");
+      expect(failEvent.trace).toContain("'Hello World'");
+      expect(failEvent.trace).toContain("/path/to/file.php:42");
+    });
+
     it("should parse a skipped test", () => {
       const output = `
 ##teamcity[testSuiteStarted name='TestClass']

--- a/packages/results/src/diff-utils.ts
+++ b/packages/results/src/diff-utils.ts
@@ -1,0 +1,101 @@
+/**
+ * Diff Highlighting Utilities
+ *
+ * Shared utilities for highlighting character-level differences between strings.
+ * Used by both Vitest and PHPUnit streaming reporters.
+ */
+
+import pc from "picocolors";
+
+/**
+ * Apply character-level highlighting to diff lines
+ * Converts «text» markers to bold/bright text
+ */
+export function applyDiffHighlighting(line: string, colorFn: (str: string) => string): string {
+  // Find all highlighted sections marked with « and »
+  const parts: string[] = [];
+  let lastIndex = 0;
+  const regex = /«([^»]+)»/g;
+  let match;
+
+  while ((match = regex.exec(line)) !== null) {
+    // Add the text before the highlight (normal color, not dimmed)
+    if (match.index > lastIndex) {
+      parts.push(colorFn(line.slice(lastIndex, match.index)));
+    }
+    // Add the highlighted text (bright/bold)
+    parts.push(pc.bold(colorFn(match[1])));
+    lastIndex = match.index + match[0].length;
+  }
+
+  // Add any remaining text after the last highlight
+  if (lastIndex < line.length) {
+    parts.push(colorFn(line.slice(lastIndex)));
+  }
+
+  // If no highlights found, return the line with color applied
+  return parts.length > 0 ? parts.join('') : colorFn(line);
+}
+
+/**
+ * Apply diff markers to multiline strings, putting markers on each line
+ * This ensures the renderer can process each line independently
+ */
+export function applyMarkersToMultiline(text: string): string {
+  if (!text) return '';
+
+  // Split by newlines, apply markers to each line, then rejoin
+  const lines = text.split('\n');
+  return lines.map(line => line ? `«${line}»` : '').join('\n');
+}
+
+/**
+ * Highlight character-level differences between two strings
+ * Adds markers for rendering differences in bold/bright
+ * Uses « and » markers that will be processed by applyDiffHighlighting
+ * Handles multiline strings by applying markers to each line individually
+ */
+export function highlightStringDiff(expected: string, actual: string): { expected: string; actual: string } {
+  // For multiline strings, apply markers to each line to ensure proper rendering
+  // Check if either string contains newlines
+  if (expected.includes('\n') || actual.includes('\n')) {
+    return {
+      expected: applyMarkersToMultiline(expected),
+      actual: applyMarkersToMultiline(actual)
+    };
+  }
+
+  // For single-line strings, use character-level diff highlighting
+  // Find common prefix
+  let prefixEnd = 0;
+  const minLen = Math.min(expected.length, actual.length);
+  while (prefixEnd < minLen && expected[prefixEnd] === actual[prefixEnd]) {
+    prefixEnd++;
+  }
+
+  // Find common suffix (starting from the end, but not overlapping with prefix)
+  let suffixStart = expected.length;
+  let actualSuffixStart = actual.length;
+  while (
+    suffixStart > prefixEnd &&
+    actualSuffixStart > prefixEnd &&
+    expected[suffixStart - 1] === actual[actualSuffixStart - 1]
+  ) {
+    suffixStart--;
+    actualSuffixStart--;
+  }
+
+  // Build highlighted strings with markers for the renderer
+  const expectedPrefix = expected.slice(0, prefixEnd);
+  const expectedDiff = expected.slice(prefixEnd, suffixStart);
+  const expectedSuffix = expected.slice(suffixStart);
+
+  const actualPrefix = actual.slice(0, prefixEnd);
+  const actualDiff = actual.slice(prefixEnd, actualSuffixStart);
+  const actualSuffix = actual.slice(actualSuffixStart);
+
+  const highlightedExpected = expectedPrefix + (expectedDiff ? `«${expectedDiff}»` : '') + expectedSuffix;
+  const highlightedActual = actualPrefix + (actualDiff ? `«${actualDiff}»` : '') + actualSuffix;
+
+  return { expected: highlightedExpected, actual: highlightedActual };
+}

--- a/packages/results/src/index.ts
+++ b/packages/results/src/index.ts
@@ -30,6 +30,13 @@ export {
   type StreamingReporterOptions,
 } from './streaming.js';
 export {
+  VitestStreamingBase,
+} from './vitest-streaming.js';
+export { applyDiffHighlighting, highlightStringDiff } from './diff-utils.js';
+export {
+  PHPUnitStreamingReporter,
+} from './phpunit-streaming-reporter.js';
+export {
   VitestStreamingReporter,
   createVitestStreamingReporter,
 } from './vitest-streaming-reporter.js';

--- a/packages/results/src/phpunit-streaming-reporter.ts
+++ b/packages/results/src/phpunit-streaming-reporter.ts
@@ -1,0 +1,28 @@
+/**
+ * PHPUnit Streaming Reporter
+ *
+ * A streaming reporter implementation for PHPUnit tests.
+ * Extends the base StreamingReporter with PHPUnit-specific behavior.
+ */
+
+import { StreamingReporter, type StreamingReporterOptions } from "./streaming.js";
+
+/**
+ * PHPUnit-specific streaming reporter
+ */
+export class PHPUnitStreamingReporter extends StreamingReporter {
+  constructor(options: StreamingReporterOptions = {}) {
+    super(options);
+  }
+
+  /**
+   * Generate PHPUnit filter command for re-running a specific test
+   * PHPUnit uses --filter with ClassName::testName format
+   */
+  protected getFilterCommand(testName: string, suiteName?: string): string | null {
+    const filterArg = suiteName
+      ? `${suiteName}::${testName}`
+      : testName;
+    return `-- --filter '${filterArg}'`;
+  }
+}

--- a/packages/results/src/streaming.ts
+++ b/packages/results/src/streaming.ts
@@ -17,6 +17,36 @@ import pc from "picocolors";
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 /**
+ * Apply character-level highlighting to diff lines
+ * Converts «text» markers to bold/bright text
+ */
+function applyDiffHighlighting(line: string, colorFn: (str: string) => string): string {
+  // Find all highlighted sections marked with « and »
+  const parts: string[] = [];
+  let lastIndex = 0;
+  const regex = /«([^»]+)»/g;
+  let match;
+
+  while ((match = regex.exec(line)) !== null) {
+    // Add the text before the highlight (normal color, not dimmed)
+    if (match.index > lastIndex) {
+      parts.push(colorFn(line.slice(lastIndex, match.index)));
+    }
+    // Add the highlighted text (bright/bold)
+    parts.push(pc.bold(colorFn(match[1])));
+    lastIndex = match.index + match[0].length;
+  }
+
+  // Add any remaining text after the last highlight
+  if (lastIndex < line.length) {
+    parts.push(colorFn(line.slice(lastIndex)));
+  }
+
+  // If no highlights found, return the line with color applied
+  return parts.length > 0 ? parts.join('') : colorFn(line);
+}
+
+/**
  * Test event emitted during test execution
  */
 export interface TestEvent {
@@ -373,19 +403,52 @@ export class StreamingReporter {
         lines.push(`${indent}${pc.red("✗")} ${test.name}${durationStr}`);
         if (test.message) {
           const messageIndent = "  ".repeat(depth + 1);
-          const indentedMessage = test.message
-            .split("\n")
-            .map((line) => `${messageIndent}${pc.red(line)}`)
-            .join("\n");
-          lines.push(indentedMessage);
+          for (const line of test.message.split("\n")) {
+            lines.push(`${messageIndent}${pc.red(line)}`);
+          }
         }
         if (test.trace) {
           const traceIndent = "  ".repeat(depth + 1);
-          const indentedTrace = test.trace
-            .split("\n")
-            .map((line) => `${traceIndent}${pc.dim(line)}`)
-            .join("\n");
-          lines.push(indentedTrace);
+          const traceLines = test.trace.split("\n");
+
+          for (let i = 0; i < traceLines.length; i++) {
+            const line = traceLines[i];
+            const trimmed = line.trim();
+
+            // Detect Expected/Actual labels and color the values
+            if (trimmed === 'Expected:' && i + 1 < traceLines.length) {
+              lines.push(`${traceIndent}${pc.dim('Expected:')}`);
+              i++; // Move to the next line (the value)
+              const valueLine = traceLines[i];
+              if (valueLine.trim()) {
+                lines.push(`${traceIndent}${applyDiffHighlighting(valueLine, pc.red)}`);
+              }
+            } else if (trimmed === 'Actual:' && i + 1 < traceLines.length) {
+              lines.push(`${traceIndent}${pc.dim('Actual:')}`);
+              i++; // Move to the next line (the value)
+              const valueLine = traceLines[i];
+              if (valueLine.trim()) {
+                lines.push(`${traceIndent}${applyDiffHighlighting(valueLine, pc.green)}`);
+              }
+            } else if (trimmed) {
+              // File paths, context lines, other trace info
+              lines.push(`${traceIndent}${pc.dim(line)}`);
+            } else {
+              // Empty lines (preserve them for spacing)
+              lines.push('');
+            }
+          }
+
+          // Add filter to re-run this specific test
+          if (test.name) {
+            lines.push('');
+            lines.push(`${traceIndent}${pc.dim('Re-run only this test by appending a filter:')}`);
+            const filterArg = test.suiteName
+              ? `${test.suiteName}::${test.name}`
+              : test.name;
+            lines.push(`${traceIndent}${pc.dim(`--filter '${filterArg}'`)}`);
+            lines.push('');
+          }
         }
         break;
       }

--- a/packages/results/src/streaming.ts
+++ b/packages/results/src/streaming.ts
@@ -10,41 +10,12 @@
 
 import type { Test, TestStatus, Report } from "ctrf";
 import pc from "picocolors";
+import { applyDiffHighlighting } from "./diff-utils.js";
 
 /**
  * Spinner frames for animated loader
  */
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-
-/**
- * Apply character-level highlighting to diff lines
- * Converts «text» markers to bold/bright text
- */
-function applyDiffHighlighting(line: string, colorFn: (str: string) => string): string {
-  // Find all highlighted sections marked with « and »
-  const parts: string[] = [];
-  let lastIndex = 0;
-  const regex = /«([^»]+)»/g;
-  let match;
-
-  while ((match = regex.exec(line)) !== null) {
-    // Add the text before the highlight (normal color, not dimmed)
-    if (match.index > lastIndex) {
-      parts.push(colorFn(line.slice(lastIndex, match.index)));
-    }
-    // Add the highlighted text (bright/bold)
-    parts.push(pc.bold(colorFn(match[1])));
-    lastIndex = match.index + match[0].length;
-  }
-
-  // Add any remaining text after the last highlight
-  if (lastIndex < line.length) {
-    parts.push(colorFn(line.slice(lastIndex)));
-  }
-
-  // If no highlights found, return the line with color applied
-  return parts.length > 0 ? parts.join('') : colorFn(line);
-}
 
 /**
  * Test event emitted during test execution
@@ -217,6 +188,14 @@ export class StreamingReporter {
   }
 
   /**
+   * Generate filter command for re-running a specific test
+   * Override in subclasses for framework-specific behavior
+   */
+  protected getFilterCommand(_testName: string, _suiteName?: string): string | null {
+    return null;
+  }
+
+  /**
    * Enable or disable run boundaries (header and summary)
    */
   setShowRunBoundaries(show: boolean): void {
@@ -250,7 +229,12 @@ export class StreamingReporter {
         this.onTestStart(event.name, event.suiteName, event.fileId);
         break;
       case "test:pass":
-        this.onTestPass(event.name, event.duration || 0, event.suiteName, event.fileId);
+        this.onTestPass(
+          event.name,
+          event.duration || 0,
+          event.suiteName,
+          event.fileId
+        );
         break;
       case "test:fail":
         this.onTestFail(
@@ -263,7 +247,12 @@ export class StreamingReporter {
         );
         break;
       case "test:skip":
-        this.onTestSkip(event.name, event.message, event.suiteName, event.fileId);
+        this.onTestSkip(
+          event.name,
+          event.message,
+          event.suiteName,
+          event.fileId
+        );
         break;
       case "test:pending":
         this.onTestPending(event.name, event.suiteName, event.fileId);
@@ -318,7 +307,10 @@ export class StreamingReporter {
     let hasRunningTests = false;
     for (const file of this.state.files.values()) {
       for (const suite of file.suites) {
-        if (suite.isLoading || suite.tests.some(t => t.status === "running")) {
+        if (
+          suite.isLoading ||
+          suite.tests.some((t) => t.status === "running")
+        ) {
           hasRunningTests = true;
           break;
         }
@@ -394,12 +386,16 @@ export class StreamingReporter {
         break;
       }
       case "passed": {
-        const durationStr = test.duration ? pc.dim(` ${formatDuration(test.duration)}`) : "";
+        const durationStr = test.duration
+          ? pc.dim(` ${formatDuration(test.duration)}`)
+          : "";
         lines.push(`${indent}${pc.green("✓")} ${test.name}${durationStr}`);
         break;
       }
       case "failed": {
-        const durationStr = test.duration ? pc.dim(` ${formatDuration(test.duration)}`) : "";
+        const durationStr = test.duration
+          ? pc.dim(` ${formatDuration(test.duration)}`)
+          : "";
         lines.push(`${indent}${pc.red("✗")} ${test.name}${durationStr}`);
         if (test.message) {
           const messageIndent = "  ".repeat(depth + 1);
@@ -415,39 +411,72 @@ export class StreamingReporter {
             const line = traceLines[i];
             const trimmed = line.trim();
 
-            // Detect Expected/Actual labels and color the values
-            if (trimmed === 'Expected:' && i + 1 < traceLines.length) {
-              lines.push(`${traceIndent}${pc.dim('Expected:')}`);
-              i++; // Move to the next line (the value)
-              const valueLine = traceLines[i];
-              if (valueLine.trim()) {
-                lines.push(`${traceIndent}${applyDiffHighlighting(valueLine, pc.red)}`);
+            // Detect Expected/Actual labels and color the values (supports multiline values)
+            if (trimmed === "Expected:" && i + 1 < traceLines.length) {
+              lines.push(`${traceIndent}${pc.dim("Expected:")}`);
+              i++; // Move to the first value line
+
+              // Continue processing lines until we hit Actual:, an empty line, or end of trace
+              while (i < traceLines.length) {
+                const valueLine = traceLines[i];
+                const valueTrimmed = valueLine.trim();
+
+                // Stop if we hit the Actual: label or empty line
+                if (valueTrimmed === "Actual:" || valueTrimmed === "") {
+                  i--; // Back up so the outer loop can process this line
+                  break;
+                }
+
+                if (valueTrimmed) {
+                  lines.push(
+                    `${traceIndent}${applyDiffHighlighting(valueLine, pc.red)}`
+                  );
+                }
+                i++;
               }
-            } else if (trimmed === 'Actual:' && i + 1 < traceLines.length) {
-              lines.push(`${traceIndent}${pc.dim('Actual:')}`);
-              i++; // Move to the next line (the value)
-              const valueLine = traceLines[i];
-              if (valueLine.trim()) {
-                lines.push(`${traceIndent}${applyDiffHighlighting(valueLine, pc.green)}`);
+            } else if (trimmed === "Actual:" && i + 1 < traceLines.length) {
+              lines.push(`${traceIndent}${pc.dim("Actual:")}`);
+              i++; // Move to the first value line
+
+              // Continue processing lines until we hit an empty line or end of trace
+              while (i < traceLines.length) {
+                const valueLine = traceLines[i];
+                const valueTrimmed = valueLine.trim();
+
+                // Stop if we hit an empty line
+                if (valueTrimmed === "") {
+                  i--; // Back up so the outer loop can process this line
+                  break;
+                }
+
+                if (valueTrimmed) {
+                  lines.push(
+                    `${traceIndent}${applyDiffHighlighting(
+                      valueLine,
+                      pc.green
+                    )}`
+                  );
+                }
+                i++;
               }
             } else if (trimmed) {
               // File paths, context lines, other trace info
               lines.push(`${traceIndent}${pc.dim(line)}`);
             } else {
               // Empty lines (preserve them for spacing)
-              lines.push('');
+              lines.push("");
             }
           }
 
           // Add filter to re-run this specific test
           if (test.name) {
-            lines.push('');
-            lines.push(`${traceIndent}${pc.dim('Re-run only this test by appending a filter:')}`);
-            const filterArg = test.suiteName
-              ? `${test.suiteName}::${test.name}`
-              : test.name;
-            lines.push(`${traceIndent}${pc.dim(`--filter '${filterArg}'`)}`);
-            lines.push('');
+            const filterCmd = this.getFilterCommand(test.name, test.suiteName);
+            if (filterCmd) {
+              lines.push(
+                `${traceIndent}${pc.dim("Re-run only this test by appending:")}`
+              );
+              lines.push(`${traceIndent}${pc.dim(filterCmd)}`);
+            }
           }
         }
         break;
@@ -491,7 +520,7 @@ export class StreamingReporter {
    */
   private getOrCreateSuite(file: FileState, suiteName: string): SuiteState {
     // Find existing suite
-    let suite = file.suites.find(s => s.name === suiteName);
+    let suite = file.suites.find((s) => s.name === suiteName);
     if (!suite) {
       suite = {
         name: suiteName,
@@ -573,7 +602,9 @@ export class StreamingReporter {
    * Called when a test suite starts
    */
   onSuiteStart(name: string, fileId?: string): void {
-    const file = fileId ? this.getOrCreateFile(fileId) : this.getOrCreateFile("__global__");
+    const file = fileId
+      ? this.getOrCreateFile(fileId)
+      : this.getOrCreateFile("__global__");
     file.currentSuiteStack.push(name);
     const suite = this.getOrCreateSuite(file, name);
 
@@ -592,7 +623,9 @@ export class StreamingReporter {
    * Called when a test suite ends
    */
   onSuiteEnd(name: string, fileId?: string): void {
-    const file = fileId ? this.state.files.get(fileId) : this.state.files.get("__global__");
+    const file = fileId
+      ? this.state.files.get(fileId)
+      : this.state.files.get("__global__");
     if (file) {
       const index = file.currentSuiteStack.lastIndexOf(name);
       if (index !== -1) {
@@ -601,7 +634,7 @@ export class StreamingReporter {
 
       // Mark suite as no longer loading when it ends
       // This ensures loaders are removed even if no tests were reported
-      const suite = file.suites.find(s => s.name === name);
+      const suite = file.suites.find((s) => s.name === name);
       if (suite) {
         suite.isLoading = false;
 
@@ -624,7 +657,9 @@ export class StreamingReporter {
    * Called when a test starts
    */
   onTestStart(name: string, suiteName?: string, fileId?: string): void {
-    const file = fileId ? this.getOrCreateFile(fileId) : this.getOrCreateFile("__global__");
+    const file = fileId
+      ? this.getOrCreateFile(fileId)
+      : this.getOrCreateFile("__global__");
     const suite = this.getOrCreateSuite(file, suiteName || "Tests");
 
     // Mark ALL suites in this file as no longer loading once any test starts
@@ -645,8 +680,15 @@ export class StreamingReporter {
   /**
    * Called when a test passes
    */
-  onTestPass(name: string, duration: number, suiteName?: string, fileId?: string): void {
-    const file = fileId ? this.getOrCreateFile(fileId) : this.getOrCreateFile("__global__");
+  onTestPass(
+    name: string,
+    duration: number,
+    suiteName?: string,
+    fileId?: string
+  ): void {
+    const file = fileId
+      ? this.getOrCreateFile(fileId)
+      : this.getOrCreateFile("__global__");
     const suite = this.getOrCreateSuite(file, suiteName || "Tests");
 
     // Mark ALL suites in this file as no longer loading once any test completes
@@ -656,10 +698,12 @@ export class StreamingReporter {
     }
 
     // Find and update the test - try exact match first, then fallback to name-only match
-    let test = suite.tests.find(t => t.name === name && t.suiteName === suiteName);
+    let test = suite.tests.find(
+      (t) => t.name === name && t.suiteName === suiteName
+    );
     if (!test) {
       // Fallback: try to find by name only (handles cases where suiteName might differ)
-      test = suite.tests.find(t => t.name === name && t.status === "running");
+      test = suite.tests.find((t) => t.name === name && t.status === "running");
     }
 
     if (test) {
@@ -690,7 +734,9 @@ export class StreamingReporter {
     suiteName?: string,
     fileId?: string
   ): void {
-    const file = fileId ? this.getOrCreateFile(fileId) : this.getOrCreateFile("__global__");
+    const file = fileId
+      ? this.getOrCreateFile(fileId)
+      : this.getOrCreateFile("__global__");
     const suite = this.getOrCreateSuite(file, suiteName || "Tests");
 
     // Mark ALL suites in this file as no longer loading once any test completes
@@ -700,10 +746,12 @@ export class StreamingReporter {
     }
 
     // Find and update the test - try exact match first, then fallback to name-only match
-    let test = suite.tests.find(t => t.name === name && t.suiteName === suiteName);
+    let test = suite.tests.find(
+      (t) => t.name === name && t.suiteName === suiteName
+    );
     if (!test) {
       // Fallback: try to find by name only (handles cases where suiteName might differ)
-      test = suite.tests.find(t => t.name === name && t.status === "running");
+      test = suite.tests.find((t) => t.name === name && t.status === "running");
     }
 
     if (test) {
@@ -730,8 +778,15 @@ export class StreamingReporter {
   /**
    * Called when a test is skipped
    */
-  onTestSkip(name: string, reason?: string, suiteName?: string, fileId?: string): void {
-    const file = fileId ? this.getOrCreateFile(fileId) : this.getOrCreateFile("__global__");
+  onTestSkip(
+    name: string,
+    reason?: string,
+    suiteName?: string,
+    fileId?: string
+  ): void {
+    const file = fileId
+      ? this.getOrCreateFile(fileId)
+      : this.getOrCreateFile("__global__");
     const suite = this.getOrCreateSuite(file, suiteName || "Tests");
 
     // Mark ALL suites in this file as no longer loading once any test completes
@@ -741,10 +796,12 @@ export class StreamingReporter {
     }
 
     // Find and update the test - try exact match first, then fallback to name-only match
-    let test = suite.tests.find(t => t.name === name && t.suiteName === suiteName);
+    let test = suite.tests.find(
+      (t) => t.name === name && t.suiteName === suiteName
+    );
     if (!test) {
       // Fallback: try to find by name only (handles cases where suiteName might differ)
-      test = suite.tests.find(t => t.name === name && t.status === "running");
+      test = suite.tests.find((t) => t.name === name && t.status === "running");
     }
 
     if (test) {
@@ -768,14 +825,18 @@ export class StreamingReporter {
    * Called when a test is pending
    */
   onTestPending(name: string, suiteName?: string, fileId?: string): void {
-    const file = fileId ? this.getOrCreateFile(fileId) : this.getOrCreateFile("__global__");
+    const file = fileId
+      ? this.getOrCreateFile(fileId)
+      : this.getOrCreateFile("__global__");
     const suite = this.getOrCreateSuite(file, suiteName || "Tests");
 
     // Mark suite as no longer loading once first test completes
     suite.isLoading = false;
 
     // Find and update the test
-    const test = suite.tests.find(t => t.name === name && t.suiteName === suiteName);
+    const test = suite.tests.find(
+      (t) => t.name === name && t.suiteName === suiteName
+    );
     if (test) {
       test.status = "pending";
     } else {
@@ -814,7 +875,9 @@ export class StreamingReporter {
     }
 
     this.writer.writeLine("");
-    this.writer.writeLine(pc.dim(`  ${this.state.totalTests} tests in ${formatDuration(duration)}`));
+    this.writer.writeLine(
+      pc.dim(`  ${this.state.totalTests} tests in ${formatDuration(duration)}`)
+    );
     this.writer.writeLine("");
 
     // Print icon legend
@@ -835,8 +898,11 @@ export class StreamingReporter {
       for (const suite of file.suites) {
         for (const test of suite.tests) {
           const ctrf: Test = {
-            name: test.suiteName ? `${test.suiteName}::${test.name}` : test.name,
-            status: test.status === "running" ? "other" : test.status as TestStatus,
+            name: test.suiteName
+              ? `${test.suiteName}::${test.name}`
+              : test.name,
+            status:
+              test.status === "running" ? "other" : (test.status as TestStatus),
             duration: test.duration || 0,
           };
 
@@ -877,7 +943,13 @@ export class StreamingReporter {
   /**
    * Get current counts for external tracking
    */
-  getCounts(): { total: number; passed: number; failed: number; skipped: number; pending: number } {
+  getCounts(): {
+    total: number;
+    passed: number;
+    failed: number;
+    skipped: number;
+    pending: number;
+  } {
     return {
       total: this.state.totalTests,
       passed: this.state.passedTests,

--- a/packages/results/src/teamcity-parser.ts
+++ b/packages/results/src/teamcity-parser.ts
@@ -16,6 +16,7 @@
 
 import type { StreamEvent } from "./streaming.js";
 import type { StreamingReporter } from "./streaming.js";
+import { highlightStringDiff } from "./diff-utils.js";
 
 /**
  * TeamCity message types we care about
@@ -54,46 +55,6 @@ function unescapeTeamCityValue(value: string): string {
     .replace(/\|\[/g, "[")
     .replace(/\|\]/g, "]")
     .replace(/\|\|/g, "|");
-}
-
-/**
- * Highlight character-level differences between two strings
- * Adds markers for rendering differences in bold/bright
- */
-function highlightStringDiff(expected: string, actual: string): { expected: string; actual: string } {
-  // Find common prefix
-  let prefixEnd = 0;
-  const minLen = Math.min(expected.length, actual.length);
-  while (prefixEnd < minLen && expected[prefixEnd] === actual[prefixEnd]) {
-    prefixEnd++;
-  }
-
-  // Find common suffix (starting from the end, but not overlapping with prefix)
-  let suffixStart = expected.length;
-  let actualSuffixStart = actual.length;
-  while (
-    suffixStart > prefixEnd &&
-    actualSuffixStart > prefixEnd &&
-    expected[suffixStart - 1] === actual[actualSuffixStart - 1]
-  ) {
-    suffixStart--;
-    actualSuffixStart--;
-  }
-
-  // Build highlighted strings with markers for the renderer
-  const expectedPrefix = expected.slice(0, prefixEnd);
-  const expectedDiff = expected.slice(prefixEnd, suffixStart);
-  const expectedSuffix = expected.slice(suffixStart);
-
-  const actualPrefix = actual.slice(0, prefixEnd);
-  const actualDiff = actual.slice(prefixEnd, actualSuffixStart);
-  const actualSuffix = actual.slice(actualSuffixStart);
-
-  // Use special markers that the renderer will detect: «diff text»
-  const highlightedExpected = expectedPrefix + (expectedDiff ? `«${expectedDiff}»` : '') + expectedSuffix;
-  const highlightedActual = actualPrefix + (actualDiff ? `«${actualDiff}»` : '') + actualSuffix;
-
-  return { expected: highlightedExpected, actual: highlightedActual };
 }
 
 /**
@@ -307,7 +268,7 @@ export class TeamCityParser {
               ].join("\n");
 
               // Reorder: path first, blank line, diff
-              trace = trace ? `${trace}\n${diffOutput}` : `\n${diffOutput}`;
+              trace = trace ? `${trace}\n${diffOutput}\n` : `\n${diffOutput}\n`;
             }
 
         this.emit({

--- a/packages/results/src/teamcity-parser.ts
+++ b/packages/results/src/teamcity-parser.ts
@@ -57,6 +57,46 @@ function unescapeTeamCityValue(value: string): string {
 }
 
 /**
+ * Highlight character-level differences between two strings
+ * Adds markers for rendering differences in bold/bright
+ */
+function highlightStringDiff(expected: string, actual: string): { expected: string; actual: string } {
+  // Find common prefix
+  let prefixEnd = 0;
+  const minLen = Math.min(expected.length, actual.length);
+  while (prefixEnd < minLen && expected[prefixEnd] === actual[prefixEnd]) {
+    prefixEnd++;
+  }
+
+  // Find common suffix (starting from the end, but not overlapping with prefix)
+  let suffixStart = expected.length;
+  let actualSuffixStart = actual.length;
+  while (
+    suffixStart > prefixEnd &&
+    actualSuffixStart > prefixEnd &&
+    expected[suffixStart - 1] === actual[actualSuffixStart - 1]
+  ) {
+    suffixStart--;
+    actualSuffixStart--;
+  }
+
+  // Build highlighted strings with markers for the renderer
+  const expectedPrefix = expected.slice(0, prefixEnd);
+  const expectedDiff = expected.slice(prefixEnd, suffixStart);
+  const expectedSuffix = expected.slice(suffixStart);
+
+  const actualPrefix = actual.slice(0, prefixEnd);
+  const actualDiff = actual.slice(prefixEnd, actualSuffixStart);
+  const actualSuffix = actual.slice(actualSuffixStart);
+
+  // Use special markers that the renderer will detect: «diff text»
+  const highlightedExpected = expectedPrefix + (expectedDiff ? `«${expectedDiff}»` : '') + expectedSuffix;
+  const highlightedActual = actualPrefix + (actualDiff ? `«${actualDiff}»` : '') + actualSuffix;
+
+  return { expected: highlightedExpected, actual: highlightedActual };
+}
+
+/**
  * Parse a single TeamCity message line
  */
 function parseTeamCityLine(line: string): TeamCityMessage | null {
@@ -245,13 +285,38 @@ export class TeamCityParser {
 
         this.testStartTimes.delete(name);
         this.completedTests.add(name); // Mark as completed to skip testFinished
+
+        // Build trace with comparison diff if available
+        let trace = attributes.details || '';
+
+        // If this is a comparison failure, format the diff with color markers
+        if (attributes.type === 'comparisonFailure' &&
+            attributes.expected !== undefined &&
+            attributes.actual !== undefined) {
+              // Highlight character-level differences for better readability
+              const highlighted = highlightStringDiff(
+                attributes.expected,
+                attributes.actual
+              );
+
+              const diffOutput = [
+                `Expected:`,
+                highlighted.expected,
+                `Actual:`,
+                highlighted.actual,
+              ].join("\n");
+
+              // Reorder: path first, blank line, diff
+              trace = trace ? `${trace}\n${diffOutput}` : `\n${diffOutput}`;
+            }
+
         this.emit({
           type: "test:fail",
           name,
           suiteName: this.currentSuite || undefined,
           duration,
           message: attributes.message,
-          trace: attributes.details,
+          trace,
         });
         break;
       }

--- a/packages/results/src/vitest-streaming-reporter.ts
+++ b/packages/results/src/vitest-streaming-reporter.ts
@@ -7,7 +7,9 @@
 
 import type { Reporter } from "vitest/reporters";
 import type { Vitest, TestModule, TestCase, TestSuite } from "vitest/node";
-import { StreamingReporter } from "./streaming.js";
+import type { SerializedError } from "@vitest/utils";
+import { VitestStreamingBase } from "./vitest-streaming.js";
+import { highlightStringDiff } from "./diff-utils.js";
 
 /**
  * Get the test state from a TestCase
@@ -31,15 +33,85 @@ function getTestDuration(testCase: TestCase): number {
 }
 
 /**
+ * Format error details with expected/actual comparison
+ */
+function formatErrorDetails(error: SerializedError): string {
+  const lines: string[] = [];
+
+  // Check if this is an assertion error with expected/actual values
+  // Some assertions like toContain() don't provide meaningful expected/actual values
+  // Only show diff if we have both values AND they're not just undefined
+  if ('actual' in error && error.actual !== undefined && 'expected' in error && error.expected !== undefined) {
+    const actualStr = typeof error.actual === 'string' ? error.actual : JSON.stringify(error.actual);
+    const expectedStr = typeof error.expected === 'string' ? error.expected : JSON.stringify(error.expected);
+
+    // Skip diff if expected is literally "undefined" - this indicates the assertion
+    // doesn't provide proper diff values (e.g., toContain)
+    if (expectedStr === 'undefined') {
+      return '';
+    }
+
+    // Highlight character-level differences using the same markers as PHPUnit (« and »)
+    const { expected, actual } = highlightStringDiff(expectedStr, actualStr);
+
+    lines.push('Expected:');
+    lines.push(expected);
+    lines.push('Actual:');
+    lines.push(actual);
+  }
+
+  return lines.join('\n');
+}
+
+/**
  * Get error message from a TestCase
  */
 function getErrorInfo(testCase: TestCase): { message?: string; trace?: string } {
   const result = testCase.result();
   if (result.state === "failed" && result.errors && result.errors.length > 0) {
     const error = result.errors[0];
+
+    // Extract base message
+    const message = error.message || (error instanceof Error ? error.toString() : JSON.stringify(error));
+
+    // Build trace with file location and error details
+    let trace = '';
+
+    // Add file location if available
+    const stackStr = error.stackStr || error.stack;
+    if (stackStr && typeof stackStr === 'string') {
+      // Extract file path and line number from stack
+      const stackLines = stackStr.split('\n');
+      const firstLine = stackLines.find((line: string) => line.includes('.spec.') || line.includes('.test.'));
+      if (firstLine) {
+        // Extract just the file path and line number - try multiple patterns
+        // Pattern 1: at /path/to/file.ts:line:column
+        let match = firstLine.match(/at\s+(\/[^:]+:\d+:\d+)/);
+        if (!match) {
+          // Pattern 2: (/path/to/file.ts:line:column)
+          match = firstLine.match(/\(([^)]+\.(?:spec|test)\.[^)]+)\)/);
+        }
+        if (match) {
+          trace = ' ' + match[1] + '\n';
+        }
+      }
+    }
+
+    // Add error details (expected/actual comparison)
+    const details = formatErrorDetails(error);
+    if (details) {
+      trace += '\n' + details;
+    }
+
+    // If we still don't have a trace but have details, use just the details
+    // This prevents showing the full node_modules stack trace
+    if (!trace && details) {
+      trace = details;
+    }
+
     return {
-      message: error.message || (error instanceof Error ? error.toString() : JSON.stringify(error)),
-      trace: error.stack,
+      message,
+      trace,
     };
   }
   return {};
@@ -102,19 +174,19 @@ function getFileIdFromTestSuite(testSuite: TestSuite): string {
  * Custom Vitest reporter that streams test results in real-time
  */
 export class VitestStreamingReporter implements Reporter {
-  private streaming: StreamingReporter;
+  private streaming: VitestStreamingBase;
   private vitest: Vitest | null = null;
   private toolName: string;
 
-  constructor(toolName: string = "vitest", streamingReporter?: StreamingReporter) {
-    this.streaming = streamingReporter || new StreamingReporter();
+  constructor(toolName: string = "vitest", streamingReporter?: VitestStreamingBase) {
+    this.streaming = streamingReporter || new VitestStreamingBase();
     this.toolName = toolName;
   }
 
   /**
    * Get the underlying StreamingReporter for access to results
    */
-  getStreamingReporter(): StreamingReporter {
+  getStreamingReporter(): VitestStreamingBase {
     return this.streaming;
   }
 

--- a/packages/results/src/vitest-streaming.ts
+++ b/packages/results/src/vitest-streaming.ts
@@ -1,0 +1,33 @@
+/**
+ * Vitest Streaming Reporter Base
+ *
+ * A streaming reporter implementation for Vitest tests.
+ * Extends the base StreamingReporter with Vitest-specific behavior.
+ */
+
+import { StreamingReporter, type StreamingReporterOptions } from "./streaming.js";
+
+/**
+ * Vitest-specific streaming reporter base class
+ */
+export class VitestStreamingBase extends StreamingReporter {
+  constructor(options: StreamingReporterOptions = {}) {
+    super(options);
+  }
+
+  /**
+   * Generate Vitest filter command for re-running a specific test
+   * Vitest uses -t or --testNamePattern with regex
+   */
+  protected getFilterCommand(testName: string, suiteName?: string): string | null {
+    // Escape special regex characters in test name
+    const escapedName = testName.replace(
+      /[.*+?^${}()|[\]\\]/g,
+      "\\$&"
+    );
+    const filterArg = suiteName
+      ? `${suiteName}.*${escapedName}`
+      : escapedName;
+    return `-- -t '${filterArg}'`;
+  }
+}

--- a/packages/smoke-tests/src/index.ts
+++ b/packages/smoke-tests/src/index.ts
@@ -4,7 +4,7 @@
  * Provides environment validation smoke tests for wp-tester.
  */
 
-import { startVitest, type Reporter } from "vitest/node";
+import { startVitest, parseCLI, type Reporter } from "vitest/node";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { WPTesterConfig, Tests, TestType } from "@wp-tester/config";
@@ -114,31 +114,25 @@ export async function runSmokeTests(
   // Build reporters array - use our streaming reporter
   const reporters: Reporter[] = [vitestReporter];
 
-  // Parse Vitest args to extract test name pattern filter
-  let testNamePattern: string | undefined;
-  if (vitestArgs && vitestArgs.length > 0) {
-    // Look for -t or --testNamePattern flag
-    const tIndex = vitestArgs.indexOf('-t');
-    const patternIndex = vitestArgs.indexOf('--testNamePattern');
-
-    if (tIndex !== -1 && tIndex + 1 < vitestArgs.length) {
-      testNamePattern = vitestArgs[tIndex + 1];
-    } else if (patternIndex !== -1 && patternIndex + 1 < vitestArgs.length) {
-      testNamePattern = vitestArgs[patternIndex + 1];
-    }
-  }
+  // Parse all Vitest CLI arguments using Vitest's built-in parser
+  // parseCLI expects "vitest" as the first argument (like process.argv)
+  const parsedArgs = vitestArgs && vitestArgs.length > 0
+    ? parseCLI(["vitest", ...vitestArgs], { allowUnknownOptions: true })
+    : { options: {}, filter: [] };
 
   // Start Vitest programmatically with our streaming reporter
-  const vitest = await startVitest("test", [], {
+  // Merge parsed CLI options with our required overrides
+  const vitest = await startVitest("test", parsedArgs.filter, {
     config: join(packageRoot, CONFIG_FILE),
     root: packageRoot,
     include: testFiles,
     run: true,
     reporters,
-    testNamePattern,
     provide: {
       config: resolvedConfig,
     },
+    // Spread parsed CLI options - these will override defaults but be overridden by explicit options above
+    ...parsedArgs.options,
   });
 
   if (!vitest) {

--- a/packages/smoke-tests/src/index.ts
+++ b/packages/smoke-tests/src/index.ts
@@ -12,7 +12,7 @@ import { resolveConfig } from "@wp-tester/config";
 import {
   EMPTY_REPORT,
   VitestStreamingReporter,
-  StreamingReporter,
+  VitestStreamingBase,
 } from "@wp-tester/results";
 import type { Report } from "@wp-tester/results";
 
@@ -69,11 +69,13 @@ export function selectTestFiles(
  *
  * @param config - Test configuration or path to config file
  * @param test - Optional filter to run only specific test type (wp, plugin, or theme)
+ * @param vitestArgs - Additional arguments to pass to Vitest CLI
  * @returns CTRF report with test results
  */
 export async function runSmokeTests(
   config: WPTesterConfig | string,
-  test?: TestType | false
+  test?: TestType | false,
+  vitestArgs?: string[]
 ): Promise<Report> {
   // Resolve config (loads from path if string, resolves paths)
   const resolvedConfig = await resolveConfig(config);
@@ -99,14 +101,32 @@ export async function runSmokeTests(
 
   // Create Vitest streaming reporter with streaming configured
   // Disable summary since the CLI will print a combined summary
+  const streamingBase = new VitestStreamingBase({
+    enabled: useStreaming,
+    showSummary: false
+  });
   const vitestReporter = new VitestStreamingReporter(
     "wp-tester-smoke-tests",
-    new StreamingReporter({ enabled: useStreaming, showSummary: false })
+    streamingBase
   );
   const reporter = vitestReporter.getStreamingReporter();
 
   // Build reporters array - use our streaming reporter
   const reporters: Reporter[] = [vitestReporter];
+
+  // Parse Vitest args to extract test name pattern filter
+  let testNamePattern: string | undefined;
+  if (vitestArgs && vitestArgs.length > 0) {
+    // Look for -t or --testNamePattern flag
+    const tIndex = vitestArgs.indexOf('-t');
+    const patternIndex = vitestArgs.indexOf('--testNamePattern');
+
+    if (tIndex !== -1 && tIndex + 1 < vitestArgs.length) {
+      testNamePattern = vitestArgs[tIndex + 1];
+    } else if (patternIndex !== -1 && patternIndex + 1 < vitestArgs.length) {
+      testNamePattern = vitestArgs[patternIndex + 1];
+    }
+  }
 
   // Start Vitest programmatically with our streaming reporter
   const vitest = await startVitest("test", [], {
@@ -115,6 +135,7 @@ export async function runSmokeTests(
     include: testFiles,
     run: true,
     reporters,
+    testNamePattern,
     provide: {
       config: resolvedConfig,
     },

--- a/packages/test-fixtures/fixtures/wp-tester-plugin/tests/UnitTest.php
+++ b/packages/test-fixtures/fixtures/wp-tester-plugin/tests/UnitTest.php
@@ -1,12 +1,11 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-use Yoast\PHPUnitPolyfills\TestCases\TestCase as PolyfillTestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Unit tests that don't require WordPress.
  */
-class UnitTest extends PolyfillTestCase {
+class UnitTest extends TestCase {
 
 	/**
 	 * Test that the sanitize function removes extra whitespace.

--- a/packages/test-fixtures/fixtures/wp-tester-plugin/tests/WordPressTest.php
+++ b/packages/test-fixtures/fixtures/wp-tester-plugin/tests/WordPressTest.php
@@ -1,12 +1,22 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-use Yoast\PHPUnitPolyfills\TestCases\TestCase as PolyfillTestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Tests that require WordPress to be loaded.
  */
-class WordPressTest extends PolyfillTestCase {
+class WordPressTest extends TestCase {
+
+	/**
+	 * Skip all tests if WordPress is not loaded.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		if ( ! function_exists( 'wp_insert_post' ) ) {
+			$this->markTestSkipped( 'WordPress is not loaded. Run tests using wp-tester CLI or set WP_LOAD_PATH environment variable.' );
+		}
+	}
 
 	/**
 	 * Test that we can create and retrieve a post using WordPress functions.

--- a/packages/test-fixtures/fixtures/wp-tester-plugin/tests/bootstrap.php
+++ b/packages/test-fixtures/fixtures/wp-tester-plugin/tests/bootstrap.php
@@ -3,11 +3,11 @@
  * PHPUnit bootstrap file for WP Tester Test Plugin.
  */
 
-// Check if we're running in wp-env or need mocks
+// Check if we're running with WordPress test library (unit mode)
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 
 if ( $_tests_dir && file_exists( $_tests_dir . '/includes/functions.php' ) ) {
-	// Running with WordPress test suite (wp-env)
+	// Unit mode: Running with WordPress test suite
 	require_once $_tests_dir . '/includes/functions.php';
 
 	// Load plugin before WordPress is loaded
@@ -17,7 +17,8 @@ if ( $_tests_dir && file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 
 	require $_tests_dir . '/includes/bootstrap.php';
 } else {
-	// Running standalone - use mock functions
+	// Standalone mode or integration mode (wp-tester already loaded WordPress)
+	// Provide mock functions for basic unit tests when running standalone
 	if ( ! function_exists( 'add_filter' ) ) {
 		function add_filter( $hook, $callback ) {
 			global $_wp_filters;
@@ -43,6 +44,8 @@ if ( $_tests_dir && file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 		}
 	}
 
-	// Load the plugin file AFTER mock functions are defined
-	require_once dirname( __DIR__ ) . '/wp-tester-plugin.php';
+	// Load the plugin file (if not already loaded by wp-tester)
+	if ( ! function_exists( 'wp_tester_sanitize_text' ) ) {
+		require_once dirname( __DIR__ ) . '/wp-tester-plugin.php';
+	}
 }


### PR DESCRIPTION
Enhances test failure reporting with better error formatting and developer experience improvements:

- **PHPUnit**: Add visual diffs for assertion failures and helpful tips in error messages
- **Smoke**: Format error output with improved readability and support all Vitest CLI arguments
- **Overall**: Better streaming test result reporting with clearer failure diagnostics

These changes make it easier to quickly identify and fix test failures by providing more actionable error information.

Fixes #157
