### PR TITLE
[Results] Fix PHPUnit test reporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3453,6 +3453,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
+      "integrity": "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -5067,6 +5082,18 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-define-property": {
@@ -7344,6 +7371,150 @@
         "node": ">=8"
       }
     },
+    "node_modules/log-update": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-7.0.2.tgz",
+      "integrity": "sha512-cSSF1K5w9juI2+JeSRAdaTUZJf6cJB0aWwWO1nQQkcWw44+bIfXmhZMwK2eEsv6tXvU3UfKX/kzcX6SP+1tLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.1.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.2",
+        "strip-ansi": "^7.1.2",
+        "wrap-ansi": "^9.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -7540,6 +7711,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mimic-response": {
@@ -9443,6 +9626,49 @@
         "node": ">=8"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -11209,6 +11435,7 @@
       "version": "0.1.2",
       "dependencies": {
         "ctrf": "^0.0.17",
+        "log-update": "^7.0.2",
         "picocolors": "^1.1.1",
         "vitest": "^4.0.13"
       },

--- a/packages/results/package.json
+++ b/packages/results/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "ctrf": "^0.0.17",
+    "log-update": "^7.0.2",
     "picocolors": "^1.1.1",
     "vitest": "^4.0.13"
   },

--- a/packages/results/src/phpunit-streaming-reporter.ts
+++ b/packages/results/src/phpunit-streaming-reporter.ts
@@ -18,11 +18,44 @@ export class PHPUnitStreamingReporter extends StreamingReporter {
   /**
    * Generate PHPUnit filter command for re-running a specific test
    * PHPUnit uses --filter with ClassName::testName format
+   *
+   * The suite stack typically contains:
+   *   - ['ActivityPub', 'Activitypub\\Tests\\Test_Class'] for regular tests
+   *   - ['ActivityPub', 'Activitypub\\Tests\\Test_Class', 'test_method'] for data providers
+   *
+   * We need to find the class name (the suite with namespace separators '\\')
+   * and use it for the filter: 'Activitypub\\Tests\\Test_Class::testName'
    */
-  protected getFilterCommand(testName: string, suiteName?: string): string | null {
+  protected getFilterCommand(testName: string, suiteName?: string, suiteStack?: string[]): string | null {
+    // If we have a suite stack, find the class name (contains namespace separator)
+    if (suiteStack && suiteStack.length > 0) {
+      // Find the last suite that contains a namespace separator (backslash)
+      // This is typically the class name
+      let className: string | null = null;
+      for (let i = suiteStack.length - 1; i >= 0; i--) {
+        if (suiteStack[i].includes('\\')) {
+          className = suiteStack[i];
+          break;
+        }
+      }
+
+      // If we found a class name, use it
+      if (className) {
+        // Escape backslashes for shell (single \ becomes \\)
+        // This allows users to copy-paste the filter directly
+        const filterArg = `${className}::${testName}`.replace(/\\/g, '\\\\');
+        return `-- --filter '${filterArg}'`;
+      }
+
+      // Otherwise, fall back to using the first suite
+      const filterArg = `${suiteStack[0]}::${testName}`.replace(/\\/g, '\\\\');
+      return `-- --filter '${filterArg}'`;
+    }
+
+    // Fallback to old behavior if no suite stack is available
     const filterArg = suiteName
       ? `${suiteName}::${testName}`
       : testName;
-    return `-- --filter '${filterArg}'`;
+    return `-- --filter '${filterArg.replace(/\\/g, '\\\\')}'`;
   }
 }

--- a/packages/results/src/streaming.spec.ts
+++ b/packages/results/src/streaming.spec.ts
@@ -8,12 +8,19 @@ import { StreamingReporter, type StreamWriter } from "./streaming.js";
 class MockWriter implements StreamWriter {
   lines: string[] = [];
   currentOutput: string[] = [];
+  savedPosition: number = 0;
 
   write(text: string): void {
-    // Handle ANSI clear codes
+    // Handle ANSI escape codes
     if (text === "\x1b[1A\x1b[2K") {
-      // Clear last line
+      // Old approach: move up one line and clear
       this.currentOutput.pop();
+    } else if (text === "\x1b[s") {
+      // Save cursor position
+      this.savedPosition = this.currentOutput.length;
+    } else if (text === "\x1b[u\x1b[J") {
+      // Restore cursor and clear to end of screen
+      this.currentOutput = this.currentOutput.slice(0, this.savedPosition);
     } else {
       this.lines.push(text);
       this.currentOutput.push(text);
@@ -36,6 +43,7 @@ class MockWriter implements StreamWriter {
   clear(): void {
     this.lines = [];
     this.currentOutput = [];
+    this.savedPosition = 0;
   }
 }
 
@@ -58,6 +66,7 @@ describe("StreamingReporter", () => {
     reporter.onEvent({ type: "test:start", name: "test 1", suiteName: "My Suite" });
     reporter.onEvent({ type: "test:pass", name: "test 1", duration: 100, suiteName: "My Suite" });
     reporter.onEvent({ type: "suite:end", name: "My Suite" });
+    reporter.onEvent({ type: "run:end" });
 
     const output = writer.getOutput();
     expect(output).toContain("My Suite");
@@ -97,6 +106,7 @@ describe("StreamingReporter", () => {
     // End files
     reporter.onEvent({ type: "file:end", fileId: "file1" });
     reporter.onEvent({ type: "file:end", fileId: "file2" });
+    reporter.onEvent({ type: "run:end" });
 
     const output = writer.getCurrentOutput();
 
@@ -131,6 +141,7 @@ describe("StreamingReporter", () => {
       suiteName: "Suite"
     });
     reporter.onEvent({ type: "suite:end", name: "Suite" });
+    reporter.onEvent({ type: "run:end" });
 
     const output = writer.getOutput();
     expect(output).toContain("failing test");
@@ -151,6 +162,7 @@ describe("StreamingReporter", () => {
       suiteName: "Suite"
     });
     reporter.onEvent({ type: "suite:end", name: "Suite" });
+    reporter.onEvent({ type: "run:end" });
 
     const output = writer.getOutput();
     expect(output).toContain("skipped test");
@@ -205,6 +217,7 @@ describe("StreamingReporter", () => {
     reporter.onEvent({ type: "suite:end", name: "Suite B", fileId: "file2" });
     reporter.onEvent({ type: "file:end", fileId: "file1" });
     reporter.onEvent({ type: "file:end", fileId: "file2" });
+    reporter.onEvent({ type: "run:end" });
 
     const counts = reporter.getCounts();
     expect(counts.total).toBe(3);
@@ -225,6 +238,7 @@ describe("StreamingReporter", () => {
     reporter.onEvent({ type: "test:pass", name: "nested test", duration: 50, suiteName: "Inner Suite" });
     reporter.onEvent({ type: "suite:end", name: "Inner Suite" });
     reporter.onEvent({ type: "suite:end", name: "Outer Suite" });
+    reporter.onEvent({ type: "run:end" });
 
     const output = writer.getOutput();
     expect(output).toContain("Outer Suite");
@@ -239,6 +253,7 @@ describe("StreamingReporter", () => {
 
     // End suite without test completion - should clean up running test
     reporter.onEvent({ type: "suite:end", name: "Suite" });
+    reporter.onEvent({ type: "run:end" });
 
     // Test should be marked as pending (not running)
     const output = writer.getCurrentOutput();
@@ -312,6 +327,7 @@ describe("StreamingReporter", () => {
     reporter.onEvent({ type: "test:start", name: "fast test", suiteName: "Suite", fileId: "file1" });
 
     reporter.onEvent({ type: "suite:end", name: "Suite", fileId: "file1" });
+    reporter.onEvent({ type: "run:end" });
 
     const counts = reporter.getCounts();
     // Should only count the test once, not create duplicate entries
@@ -347,6 +363,7 @@ describe("StreamingReporter", () => {
 
     reporter.onEvent({ type: "file:end", fileId: "file1" });
     reporter.onEvent({ type: "file:end", fileId: "file2" });
+    reporter.onEvent({ type: "run:end" });
 
     const counts = reporter.getCounts();
     // Should count both tests separately, not create duplicates

--- a/packages/results/src/streaming.ts
+++ b/packages/results/src/streaming.ts
@@ -190,6 +190,11 @@ export class StreamingReporter {
   private spinnerFrame = 0;
   private spinnerInterval: NodeJS.Timeout | null = null;
 
+  // Throttling state
+  private renderThrottleTimeout: NodeJS.Timeout | null = null;
+  private pendingRender = false;
+  private readonly renderInterval = 50; // Render at most every 50ms (~20fps)
+
   constructor(options: StreamingReporterOptions = {}) {
     this.writer = options.writer ?? stdoutWriter;
     this.showRunBoundaries = options.showRunBoundaries ?? true;
@@ -327,10 +332,52 @@ export class StreamingReporter {
   }
 
   /**
-   * Render the current state to output
+   * Clear throttle timeout and execute any pending render
+   */
+  private clearThrottle(): void {
+    if (this.renderThrottleTimeout) {
+      clearTimeout(this.renderThrottleTimeout);
+      this.renderThrottleTimeout = null;
+    }
+    // Execute any pending render
+    if (this.pendingRender) {
+      this.renderImmediate();
+    }
+  }
+
+  /**
+   * Render the current state to output (throttled)
    */
   private render(): void {
     if (!this.enabled) return;
+
+    // Mark that a render is pending
+    this.pendingRender = true;
+
+    // If we're already waiting for a throttled render, just update the flag
+    if (this.renderThrottleTimeout) {
+      return;
+    }
+
+    // Execute render immediately and schedule the next allowed render time
+    this.renderThrottleTimeout = setTimeout(() => {
+      this.renderThrottleTimeout = null;
+
+      // If another render was requested while throttled, execute it now
+      if (this.pendingRender) {
+        this.renderImmediate();
+      }
+    }, this.renderInterval);
+
+    // Execute the first render immediately
+    this.renderImmediate();
+  }
+
+  /**
+   * Execute render immediately without throttling
+   */
+  private renderImmediate(): void {
+    this.pendingRender = false;
 
     // Build output lines
     const lines: string[] = [];
@@ -726,6 +773,13 @@ export class StreamingReporter {
     if (this.useLogUpdate) {
       logUpdate.clear();
     }
+
+    // Clear any previous throttle state
+    if (this.renderThrottleTimeout) {
+      clearTimeout(this.renderThrottleTimeout);
+      this.renderThrottleTimeout = null;
+    }
+    this.pendingRender = false;
   }
 
   /**
@@ -733,6 +787,7 @@ export class StreamingReporter {
    */
   onRunEnd(): void {
     this.stopSpinner();
+    this.clearThrottle(); // Clear any pending throttled renders
     this.state.isRunning = false;
 
     // Clean up any tests still in "running" state across all files

--- a/packages/results/src/streaming.ts
+++ b/packages/results/src/streaming.ts
@@ -134,6 +134,7 @@ interface SuiteState {
   depth: number;
   tests: TestState[];
   isLoading: boolean; // True when suite has started but no tests have been reported yet
+  parentStack: string[]; // Stack of parent suite names when this suite was created
 }
 
 /**
@@ -643,14 +644,42 @@ export class StreamingReporter {
    * Find or create a suite in a file
    */
   private getOrCreateSuite(file: FileState, suiteName: string): SuiteState {
-    // Find existing suite
-    let suite = file.suites.find((s) => s.name === suiteName);
+    // Find existing suite with matching name, depth, AND parent context
+    // This prevents suites with the same name from being confused when they're
+    // in different branches of the suite tree (e.g., Test_Accept::test_method
+    // vs Test_Reject::test_method both creating a "test_method" sub-suite)
+    const currentDepth = file.currentSuiteStack.length;
+
+    // Create a snapshot of the current parent stack (excluding the current suite name)
+    const parentStack = [...file.currentSuiteStack];
+
+    // Find a suite with matching name, depth, and parent stack
+    let suite = file.suites.find((s) => {
+      if (s.name !== suiteName || s.depth !== currentDepth) {
+        return false;
+      }
+
+      // Check if parent stacks match
+      if (s.parentStack.length !== parentStack.length) {
+        return false;
+      }
+
+      for (let i = 0; i < parentStack.length; i++) {
+        if (s.parentStack[i] !== parentStack[i]) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+
     if (!suite) {
       suite = {
         name: suiteName,
-        depth: file.currentSuiteStack.length,
+        depth: currentDepth,
         tests: [],
         isLoading: true, // Start in loading state
+        parentStack: parentStack,
       };
       file.suites.push(suite);
     }

--- a/packages/results/src/streaming.ts
+++ b/packages/results/src/streaming.ts
@@ -12,6 +12,7 @@ import type { Test, TestStatus, Report } from "ctrf";
 import pc from "picocolors";
 import { applyDiffHighlighting } from "./diff-utils.js";
 import { SPINNER_FRAMES } from "./spinner.js";
+import logUpdate from "log-update";
 
 /**
  * Test event emitted during test execution
@@ -177,12 +178,12 @@ export class StreamingReporter {
   private showRunBoundaries = true;
   private showSummary = true;
   private filter: ReporterFilterOptions;
+  private useLogUpdate: boolean;
 
   // Unified state
   private state: ReporterState;
 
   // Rendering state
-  private lastOutputLineCount = 0;
   private spinnerFrame = 0;
   private spinnerInterval: NodeJS.Timeout | null = null;
 
@@ -191,6 +192,13 @@ export class StreamingReporter {
     this.showRunBoundaries = options.showRunBoundaries ?? true;
     this.showSummary = options.showSummary ?? true;
     this.enabled = options.enabled ?? true;
+
+    // Use log-update only if:
+    // - Reporter is enabled
+    // - We're using the default stdout writer (not a custom writer)
+    // - stdout is a TTY (log-update handles this check internally)
+    this.useLogUpdate = this.enabled && this.writer === stdoutWriter && (process.stdout.isTTY ?? false);
+
     // Default filter: show all statuses (for backwards compatibility)
     this.filter = options.filter ?? {
       passed: true,
@@ -217,7 +225,10 @@ export class StreamingReporter {
    * Generate filter command for re-running a specific test
    * Override in subclasses for framework-specific behavior
    */
-  protected getFilterCommand(_testName: string, _suiteName?: string): string | null {
+  protected getFilterCommand(
+    _testName: string,
+    _suiteName?: string,
+  ): string | null {
     return null;
   }
 
@@ -259,7 +270,7 @@ export class StreamingReporter {
           event.name,
           event.duration || 0,
           event.suiteName,
-          event.fileId
+          event.fileId,
         );
         break;
       case "test:fail":
@@ -269,7 +280,7 @@ export class StreamingReporter {
           event.message,
           event.trace,
           event.suiteName,
-          event.fileId
+          event.fileId,
         );
         break;
       case "test:skip":
@@ -277,7 +288,7 @@ export class StreamingReporter {
           event.name,
           event.message,
           event.suiteName,
-          event.fileId
+          event.fileId,
         );
         break;
       case "test:pending":
@@ -305,18 +316,6 @@ export class StreamingReporter {
     if (this.spinnerInterval) {
       clearInterval(this.spinnerInterval);
       this.spinnerInterval = null;
-    }
-  }
-
-  /**
-   * Clear the previous output
-   */
-  private clearPreviousOutput(): void {
-    if (!this.enabled || this.lastOutputLineCount === 0) return;
-
-    // Move cursor up and clear each line
-    for (let i = 0; i < this.lastOutputLineCount; i++) {
-      this.writer.write("\x1b[1A\x1b[2K");
     }
   }
 
@@ -349,20 +348,38 @@ export class StreamingReporter {
       this.renderFile(file, lines);
     }
 
-    // Clear previous output and render new output
-    this.clearPreviousOutput();
-
-    for (const line of lines) {
-      this.writer.writeLine(line);
+    // Render output based on environment
+    if (this.useLogUpdate) {
+      // TTY mode: use log-update for live updates with clearing
+      logUpdate(lines.join('\n'));
+    } else {
+      // Non-TTY mode or custom writer: render once only when tests complete
+      // Skip intermediate renders to avoid duplicate output
+      // Tests and non-interactive environments see final state only
     }
-
-    this.lastOutputLineCount = lines.length;
 
     // Start/stop spinner based on running tests
     if (hasRunningTests && !this.spinnerInterval) {
       this.startSpinner();
     } else if (!hasRunningTests && this.spinnerInterval) {
       this.stopSpinner();
+    }
+  }
+
+  /**
+   * Render final output (used in non-interactive mode)
+   */
+  private renderFinal(): void {
+    const lines: string[] = [];
+
+    // Render each file
+    for (const file of this.state.files.values()) {
+      this.renderFile(file, lines);
+    }
+
+    // Write final output
+    for (const line of lines) {
+      this.writer.writeLine(line);
     }
   }
 
@@ -378,7 +395,9 @@ export class StreamingReporter {
     }
 
     // Check if suite has any visible tests
-    const hasVisibleTests = suite.tests.some(test => this.shouldShowStatus(test.status));
+    const hasVisibleTests = suite.tests.some((test) =>
+      this.shouldShowStatus(test.status),
+    );
     if (hasVisibleTests) {
       return true;
     }
@@ -416,7 +435,11 @@ export class StreamingReporter {
   /**
    * Render a suite and its tests
    */
-  private renderSuite(file: FileState, suiteIndex: number, lines: string[]): void {
+  private renderSuite(
+    file: FileState,
+    suiteIndex: number,
+    lines: string[],
+  ): void {
     const suite = file.suites[suiteIndex];
     const indent = "  ".repeat(suite.depth);
 
@@ -460,7 +483,10 @@ export class StreamingReporter {
     }
 
     // Map status to filter property
-    const filterMap: Record<Exclude<TestState["status"], "running">, keyof ReporterFilterOptions> = {
+    const filterMap: Record<
+      Exclude<TestState["status"], "running">,
+      keyof ReporterFilterOptions
+    > = {
       passed: "passed",
       failed: "failed",
       skipped: "skipped",
@@ -527,7 +553,7 @@ export class StreamingReporter {
 
                 if (valueTrimmed) {
                   lines.push(
-                    `${traceIndent}${applyDiffHighlighting(valueLine, pc.red)}`
+                    `${traceIndent}${applyDiffHighlighting(valueLine, pc.red)}`,
                   );
                 }
                 i++;
@@ -551,8 +577,8 @@ export class StreamingReporter {
                   lines.push(
                     `${traceIndent}${applyDiffHighlighting(
                       valueLine,
-                      pc.green
-                    )}`
+                      pc.green,
+                    )}`,
                   );
                 }
                 i++;
@@ -571,7 +597,7 @@ export class StreamingReporter {
             const filterCmd = this.getFilterCommand(test.name, test.suiteName);
             if (filterCmd) {
               lines.push(
-                `${traceIndent}${pc.dim("Re-run only this test by appending:")}`
+                `${traceIndent}${pc.dim("Re-run only this test by appending:")}`,
               );
               lines.push(`${traceIndent}${pc.dim(filterCmd)}`);
             }
@@ -584,7 +610,7 @@ export class StreamingReporter {
           ? ` ${pc.dim(`(${test.message})`)}`
           : ` ${pc.dim("(Skipped)")}`;
         lines.push(
-          `${indent}${pc.yellow("○")} ${pc.dim(test.name)}${reasonStr}`
+          `${indent}${pc.yellow("○")} ${pc.dim(test.name)}${reasonStr}`,
         );
         break;
       }
@@ -661,7 +687,10 @@ export class StreamingReporter {
       isRunning: true,
     };
 
-    this.lastOutputLineCount = 0;
+    // Clear any previous log-update state
+    if (this.useLogUpdate) {
+      logUpdate.clear();
+    }
   }
 
   /**
@@ -688,7 +717,15 @@ export class StreamingReporter {
     }
 
     // Final render
-    this.render();
+    if (this.useLogUpdate) {
+      // Clear the live updating display
+      logUpdate.clear();
+      logUpdate.done();
+    }
+
+    // Always use renderFinal for the final output to avoid truncation
+    // log-update is only for live updates, not for final large output
+    this.renderFinal();
 
     if (!this.enabled || !this.showSummary) return;
 
@@ -783,7 +820,9 @@ export class StreamingReporter {
     }
 
     // Check if test already exists (completion event arrived before start event)
-    const existingTest = suite.tests.find((t) => t.name === name && t.suiteName === suiteName);
+    const existingTest = suite.tests.find(
+      (t) => t.name === name && t.suiteName === suiteName,
+    );
     if (!existingTest) {
       // Test doesn't exist yet - create it in running state
       suite.tests.push({
@@ -804,7 +843,7 @@ export class StreamingReporter {
     name: string,
     duration: number,
     suiteName?: string,
-    fileId?: string
+    fileId?: string,
   ): void {
     const file = fileId
       ? this.getOrCreateFile(fileId)
@@ -820,12 +859,14 @@ export class StreamingReporter {
     // Find and update the test
     // Look for a test in "running" state first (most common case - completion follows start)
     let test = suite.tests.find(
-      (t) => t.name === name && t.status === "running"
+      (t) => t.name === name && t.status === "running",
     );
 
     if (!test) {
       // Fallback: try exact match with suiteName (handles case where test completed before start event)
-      test = suite.tests.find((t) => t.name === name && t.suiteName === suiteName);
+      test = suite.tests.find(
+        (t) => t.name === name && t.suiteName === suiteName,
+      );
     }
 
     if (test) {
@@ -856,7 +897,7 @@ export class StreamingReporter {
     message?: string,
     trace?: string,
     suiteName?: string,
-    fileId?: string
+    fileId?: string,
   ): void {
     const file = fileId
       ? this.getOrCreateFile(fileId)
@@ -871,11 +912,15 @@ export class StreamingReporter {
 
     // Find and update the test
     // Look for a test in "running" state first (most common case - completion follows start)
-    let test = suite.tests.find((t) => t.name === name && t.status === "running");
+    let test = suite.tests.find(
+      (t) => t.name === name && t.status === "running",
+    );
 
     if (!test) {
       // Fallback: try exact match with suiteName (handles case where test completed before start event)
-      test = suite.tests.find((t) => t.name === name && t.suiteName === suiteName);
+      test = suite.tests.find(
+        (t) => t.name === name && t.suiteName === suiteName,
+      );
     }
 
     if (test) {
@@ -908,7 +953,7 @@ export class StreamingReporter {
     name: string,
     reason?: string,
     suiteName?: string,
-    fileId?: string
+    fileId?: string,
   ): void {
     const file = fileId
       ? this.getOrCreateFile(fileId)
@@ -923,11 +968,15 @@ export class StreamingReporter {
 
     // Find and update the test
     // Look for a test in "running" state first (most common case - completion follows start)
-    let test = suite.tests.find((t) => t.name === name && t.status === "running");
+    let test = suite.tests.find(
+      (t) => t.name === name && t.status === "running",
+    );
 
     if (!test) {
       // Fallback: try exact match with suiteName (handles case where test completed before start event)
-      test = suite.tests.find((t) => t.name === name && t.suiteName === suiteName);
+      test = suite.tests.find(
+        (t) => t.name === name && t.suiteName === suiteName,
+      );
     }
 
     if (test) {
@@ -963,7 +1012,7 @@ export class StreamingReporter {
 
     // Find and update the test
     const test = suite.tests.find(
-      (t) => t.name === name && t.suiteName === suiteName
+      (t) => t.name === name && t.suiteName === suiteName,
     );
     if (test) {
       test.status = "pending";
@@ -993,24 +1042,24 @@ export class StreamingReporter {
     }
     if (this.state.skippedTests > 0) {
       this.writer.writeLine(
-        pc.yellow(`  ○ ${this.state.skippedTests} skipped`)
+        pc.yellow(`  ○ ${this.state.skippedTests} skipped`),
       );
     }
     if (this.state.pendingTests > 0) {
       this.writer.writeLine(
-        pc.yellow(`  ◔ ${this.state.pendingTests} pending`)
+        pc.yellow(`  ◔ ${this.state.pendingTests} pending`),
       );
     }
 
     this.writer.writeLine("");
     this.writer.writeLine(
-      pc.dim(`  ${this.state.totalTests} tests in ${formatDuration(duration)}`)
+      pc.dim(`  ${this.state.totalTests} tests in ${formatDuration(duration)}`),
     );
     this.writer.writeLine("");
 
     // Print icon legend
     this.writer.writeLine(
-      pc.dim("  Legend: ✓ passed  ✗ failed  ○ skipped  ◔ pending")
+      pc.dim("  Legend: ✓ passed  ✗ failed  ○ skipped  ◔ pending"),
     );
     this.writer.writeLine("");
   }

--- a/packages/results/src/streaming.ts
+++ b/packages/results/src/streaming.ts
@@ -21,6 +21,7 @@ export interface TestEvent {
   type: "test:start" | "test:pass" | "test:fail" | "test:skip" | "test:pending";
   name: string;
   suiteName?: string;
+  suiteStack?: string[]; // Full suite hierarchy (e.g., ['ClassName', 'testMethod'] for data providers)
   duration?: number;
   message?: string;
   trace?: string;
@@ -120,6 +121,7 @@ export interface StreamingReporterOptions {
 interface TestState {
   name: string;
   suiteName?: string;
+  suiteStack?: string[]; // Full suite hierarchy for generating filters
   status: "running" | "passed" | "failed" | "skipped" | "pending";
   duration?: number;
   message?: string;
@@ -229,6 +231,7 @@ export class StreamingReporter {
   protected getFilterCommand(
     _testName: string,
     _suiteName?: string,
+    _suiteStack?: string[],
   ): string | null {
     return null;
   }
@@ -264,13 +267,14 @@ export class StreamingReporter {
         this.onSuiteEnd(event.name, event.fileId);
         break;
       case "test:start":
-        this.onTestStart(event.name, event.suiteName, event.fileId);
+        this.onTestStart(event.name, event.suiteName, event.suiteStack, event.fileId);
         break;
       case "test:pass":
         this.onTestPass(
           event.name,
           event.duration || 0,
           event.suiteName,
+          event.suiteStack,
           event.fileId,
         );
         break;
@@ -281,6 +285,7 @@ export class StreamingReporter {
           event.message,
           event.trace,
           event.suiteName,
+          event.suiteStack,
           event.fileId,
         );
         break;
@@ -289,11 +294,12 @@ export class StreamingReporter {
           event.name,
           event.message,
           event.suiteName,
+          event.suiteStack,
           event.fileId,
         );
         break;
       case "test:pending":
-        this.onTestPending(event.name, event.suiteName, event.fileId);
+        this.onTestPending(event.name, event.suiteName, event.suiteStack, event.fileId);
         break;
     }
   }
@@ -595,7 +601,7 @@ export class StreamingReporter {
 
           // Add filter to re-run this specific test
           if (test.name) {
-            const filterCmd = this.getFilterCommand(test.name, test.suiteName);
+            const filterCmd = this.getFilterCommand(test.name, test.suiteName, test.suiteStack);
             if (filterCmd) {
               lines.push(
                 `${traceIndent}${pc.dim("Re-run only this test by appending:")}`,
@@ -836,7 +842,7 @@ export class StreamingReporter {
   /**
    * Called when a test starts
    */
-  onTestStart(name: string, suiteName?: string, fileId?: string): void {
+  onTestStart(name: string, suiteName?: string, suiteStack?: string[], fileId?: string): void {
     const file = fileId
       ? this.getOrCreateFile(fileId)
       : this.getOrCreateFile("__global__");
@@ -857,6 +863,7 @@ export class StreamingReporter {
       suite.tests.push({
         name,
         suiteName,
+        suiteStack,
         status: "running",
       });
     }
@@ -872,6 +879,7 @@ export class StreamingReporter {
     name: string,
     duration: number,
     suiteName?: string,
+    suiteStack?: string[],
     fileId?: string,
   ): void {
     const file = fileId
@@ -902,11 +910,13 @@ export class StreamingReporter {
       test.status = "passed";
       test.duration = duration;
       test.suiteName = suiteName; // Ensure suiteName is set
+      test.suiteStack = suiteStack;
     } else {
       // Test start event hasn't arrived yet - create the test with completed state
       suite.tests.push({
         name,
         suiteName,
+        suiteStack,
         status: "passed",
         duration,
       });
@@ -926,6 +936,7 @@ export class StreamingReporter {
     message?: string,
     trace?: string,
     suiteName?: string,
+    suiteStack?: string[],
     fileId?: string,
   ): void {
     const file = fileId
@@ -958,11 +969,13 @@ export class StreamingReporter {
       test.message = message;
       test.trace = trace;
       test.suiteName = suiteName; // Ensure suiteName is set
+      test.suiteStack = suiteStack;
     } else {
       // Test start event hasn't arrived yet - create the test with completed state
       suite.tests.push({
         name,
         suiteName,
+        suiteStack,
         status: "failed",
         duration,
         message,
@@ -982,6 +995,7 @@ export class StreamingReporter {
     name: string,
     reason?: string,
     suiteName?: string,
+    suiteStack?: string[],
     fileId?: string,
   ): void {
     const file = fileId
@@ -1012,11 +1026,13 @@ export class StreamingReporter {
       test.status = "skipped";
       test.message = reason;
       test.suiteName = suiteName; // Ensure suiteName is set
+      test.suiteStack = suiteStack;
     } else {
       // Test start event hasn't arrived yet - create the test with completed state
       suite.tests.push({
         name,
         suiteName,
+        suiteStack,
         status: "skipped",
         message: reason,
       });
@@ -1030,7 +1046,7 @@ export class StreamingReporter {
   /**
    * Called when a test is pending
    */
-  onTestPending(name: string, suiteName?: string, fileId?: string): void {
+  onTestPending(name: string, suiteName?: string, suiteStack?: string[], fileId?: string): void {
     const file = fileId
       ? this.getOrCreateFile(fileId)
       : this.getOrCreateFile("__global__");
@@ -1045,10 +1061,12 @@ export class StreamingReporter {
     );
     if (test) {
       test.status = "pending";
+      test.suiteStack = suiteStack;
     } else {
       suite.tests.push({
         name,
         suiteName,
+        suiteStack,
         status: "pending",
       });
     }

--- a/packages/results/src/teamcity-parser.ts
+++ b/packages/results/src/teamcity-parser.ts
@@ -202,6 +202,15 @@ export class TeamCityParser {
   }
 
   /**
+   * Get the full suite stack for a specific flow.
+   * Returns a copy to prevent mutations from affecting stored test data.
+   */
+  private getSuiteStack(flowId: string): string[] {
+    const stack = this.suiteStacks.get(flowId);
+    return stack ? [...stack] : [];
+  }
+
+  /**
    * Push a suite onto the stack for a specific flow.
    */
   private pushSuite(flowId: string, suiteName: string): void {
@@ -257,6 +266,7 @@ export class TeamCityParser {
           type: "test:start",
           name,
           suiteName: this.getCurrentSuite(flowId) || undefined,
+          suiteStack: this.getSuiteStack(flowId),
         });
         break;
 
@@ -281,6 +291,7 @@ export class TeamCityParser {
           type: "test:pass",
           name,
           suiteName: this.getCurrentSuite(flowId) || undefined,
+          suiteStack: this.getSuiteStack(flowId),
           duration,
         });
         break;
@@ -325,6 +336,7 @@ export class TeamCityParser {
           type: "test:fail",
           name,
           suiteName: this.getCurrentSuite(flowId) || undefined,
+          suiteStack: this.getSuiteStack(flowId),
           duration,
           message: attributes.message,
           trace,
@@ -339,6 +351,7 @@ export class TeamCityParser {
           type: "test:skip",
           name,
           suiteName: this.getCurrentSuite(flowId) || undefined,
+          suiteStack: this.getSuiteStack(flowId),
           message: attributes.message,
         });
         break;

--- a/packages/results/src/teamcity-parser.ts
+++ b/packages/results/src/teamcity-parser.ts
@@ -93,7 +93,7 @@ function parseTeamCityLine(line: string): TeamCityMessage | null {
  */
 export class TeamCityParser {
   private buffer = "";
-  private currentSuite: string | null = null;
+  private suiteStacks: Map<string, string[]> = new Map(); // Track suite stack per flowId
   private testStartTimes: Map<string, number> = new Map();
   private completedTests: Set<string> = new Set(); // Track tests that already reported result
   private reporter: StreamingReporter | null = null;
@@ -186,16 +186,57 @@ export class TeamCityParser {
   }
 
   /**
+   * Get the flow identifier from attributes.
+   * Returns flowId if present, otherwise "default" for sequential execution.
+   */
+  private getFlowId(attributes: Record<string, string>): string {
+    return attributes.flowId || "default";
+  }
+
+  /**
+   * Get the current suite for a specific flow.
+   */
+  private getCurrentSuite(flowId: string): string | null {
+    const stack = this.suiteStacks.get(flowId);
+    return stack && stack.length > 0 ? stack[stack.length - 1] : null;
+  }
+
+  /**
+   * Push a suite onto the stack for a specific flow.
+   */
+  private pushSuite(flowId: string, suiteName: string): void {
+    if (!this.suiteStacks.has(flowId)) {
+      this.suiteStacks.set(flowId, []);
+    }
+    this.suiteStacks.get(flowId)!.push(suiteName);
+  }
+
+  /**
+   * Pop a suite from the stack for a specific flow.
+   */
+  private popSuite(flowId: string, suiteName: string): void {
+    const stack = this.suiteStacks.get(flowId);
+    if (stack && stack.length > 0) {
+      // Pop the last suite if it matches the name
+      const lastSuite = stack[stack.length - 1];
+      if (lastSuite === suiteName) {
+        stack.pop();
+      }
+    }
+  }
+
+  /**
    * Handle a parsed TeamCity message
    */
   private handleMessage(message: TeamCityMessage): void {
     const { type, attributes } = message;
     const name = attributes.name || "Unknown";
     const identifier = this.getTestIdentifier(attributes);
+    const flowId = this.getFlowId(attributes);
 
     switch (type) {
       case "testSuiteStarted":
-        this.currentSuite = name;
+        this.pushSuite(flowId, name);
         this.emit({
           type: "suite:start",
           name,
@@ -207,9 +248,7 @@ export class TeamCityParser {
           type: "suite:end",
           name,
         });
-        if (this.currentSuite === name) {
-          this.currentSuite = null;
-        }
+        this.popSuite(flowId, name);
         break;
 
       case "testStarted":
@@ -217,7 +256,7 @@ export class TeamCityParser {
         this.emit({
           type: "test:start",
           name,
-          suiteName: this.currentSuite || undefined,
+          suiteName: this.getCurrentSuite(flowId) || undefined,
         });
         break;
 
@@ -241,7 +280,7 @@ export class TeamCityParser {
         this.emit({
           type: "test:pass",
           name,
-          suiteName: this.currentSuite || undefined,
+          suiteName: this.getCurrentSuite(flowId) || undefined,
           duration,
         });
         break;
@@ -285,7 +324,7 @@ export class TeamCityParser {
         this.emit({
           type: "test:fail",
           name,
-          suiteName: this.currentSuite || undefined,
+          suiteName: this.getCurrentSuite(flowId) || undefined,
           duration,
           message: attributes.message,
           trace,
@@ -299,7 +338,7 @@ export class TeamCityParser {
         this.emit({
           type: "test:skip",
           name,
-          suiteName: this.currentSuite || undefined,
+          suiteName: this.getCurrentSuite(flowId) || undefined,
           message: attributes.message,
         });
         break;
@@ -312,7 +351,7 @@ export class TeamCityParser {
    */
   reset(): void {
     this.buffer = "";
-    this.currentSuite = null;
+    this.suiteStacks.clear();
     this.testStartTimes.clear();
     this.completedTests.clear();
   }


### PR DESCRIPTION
Before this PR, PHPUnit reporting didn't correctly clear outputs before rendering. As a result, multiple reports would be rendered in the terminal.

Additionally, this PR fixes PHPUnit test grouping and filter hints.