### PR TITLE
[CI] Add automatic Composer dependency detection and pre-release version support

### DIFF
--- a/.github/workflows/wp-tester-plugin.yml
+++ b/.github/workflows/wp-tester-plugin.yml
@@ -1,3 +1,5 @@
+name: WP Tester9
+
 # WP Tester - WordPress Testing Workflow
 # This workflow runs wp-tester to test your WordPress plugin/theme
 #
@@ -5,14 +7,12 @@
 #
 # Configuration:
 # - Branches: trunk
-# - Node.js: 22
+# - Node.js: 20
 # - Caching: enabled
 #
 # To customize:
 # - Add arguments like --test=phpunit or --failed-only
 # - See 'npx wp-tester --help' for all available options
-
-name: WP Tester
 
 on:
   push:
@@ -28,7 +28,7 @@ on:
 
 jobs:
   test:
-    name: WP Tester
+    name: WP Tester Plugin Test
     runs-on: ubuntu-latest
 
     steps:
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '20'
 
       - name: Cache node modules
         uses: actions/cache@v4
@@ -50,11 +50,10 @@ jobs:
 
       - name: Install Composer dependencies
         run: composer install --no-interaction --prefer-dist
-        working-directory: ./packages/test-fixtures/fixtures/wp-tester-theme
+        working-directory: packages/test-fixtures/fixtures/wp-tester-plugin
 
       - name: Run WP Tester
         run: >
           npx @wp-tester/cli@latest test
-          --config=./packages/test-fixtures/fixtures/wp-tester-theme/wp-tester.json
-          --test=phpunit
           ${{ github.event.inputs.wp-tester-args }}
+        working-directory: packages/test-fixtures/fixtures/wp-tester-plugin

--- a/.github/workflows/wp-tester-plugin.yml
+++ b/.github/workflows/wp-tester-plugin.yml
@@ -28,7 +28,6 @@ on:
 
 jobs:
   test:
-    name: WP Tester Plugin Test
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/wp-tester-theme.yml
+++ b/.github/workflows/wp-tester-theme.yml
@@ -1,5 +1,3 @@
-name: WP Tester Theme Test
-
 # WP Tester - WordPress Testing Workflow
 # This workflow runs wp-tester to test your WordPress plugin/theme
 #

--- a/.github/workflows/wp-tester-theme.yml
+++ b/.github/workflows/wp-tester-theme.yml
@@ -1,0 +1,60 @@
+name: WP Tester Theme Test
+
+# WP Tester - WordPress Testing Workflow
+# This workflow runs wp-tester to test your WordPress plugin/theme
+#
+# For more information, see: https://github.com/bgrgicak/wp-tester
+#
+# Configuration:
+# - Branches: trunk
+# - Node.js: 22
+# - Caching: enabled
+#
+# To customize:
+# - Add arguments like --test=phpunit or --failed-only
+# - See 'npx wp-tester --help' for all available options
+
+on:
+  push:
+    branches: [trunk]
+  pull_request:
+    branches: [trunk]
+  workflow_dispatch:
+    inputs:
+      wp-tester-args:
+        description: 'Additional arguments for wp-tester'
+        required: false
+        default: ''
+
+jobs:
+  test:
+    name: WP Tester Theme Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist
+        working-directory: packages/test-fixtures/fixtures/wp-tester-theme
+
+      - name: Run WP Tester
+        run: >
+          npx @wp-tester/cli@latest test
+          --test=phpunit
+          ${{ github.event.inputs.wp-tester-args }}
+        working-directory: packages/test-fixtures/fixtures/wp-tester-theme

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ See the [Installation Guide](docs/README.md#installation) for details on when to
 - **Multiple Test Types** - Smoke tests, PHPUnit tests, and custom tests
 - **WordPress Playground** - Isolated environments with no local setup
 - **Flexible Configuration** - JSON-based with IDE autocomplete support
+- **GitHub Actions Integration** - Auto-generate CI workflows with `wp-tester config ci`
 
 ## Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -265,7 +265,32 @@ wp-tester config project-type
 wp-tester config project-root
 wp-tester config phpunit
 wp-tester config smoke-tests
+wp-tester config ci
 ```
+
+#### CI Configuration
+
+Set up GitHub Actions workflow for automated testing:
+
+```bash
+wp-tester config ci
+```
+
+This interactive setup will:
+- Detect your git repository settings and default branch
+- Auto-detect Composer dependencies if present
+- Create a GitHub Actions workflow file
+- Configure trigger branches, Node.js version, and caching options
+
+The workflow runs `wp-tester` on push/pull requests and can be manually triggered with custom arguments.
+
+**What gets configured:**
+- Workflow name and file path (default: `.github/workflows/wp-tester.yml`)
+- Target branches for CI triggers
+- Node.js version (18, 20, or 22)
+- NPM caching for faster builds
+- Composer dependency installation (if detected)
+- WP Tester CLI arguments
 
 ## Packages
 

--- a/packages/cli/src/commands/config/index.ts
+++ b/packages/cli/src/commands/config/index.ts
@@ -23,7 +23,7 @@ export const configHandler = async (argv: ConfigArgs): Promise<void> => {
     const summary = generateConfigSummary(validatedConfig);
     printConfigSummary(summary);
   } else if (action && optionNames.includes(action as OptionName)) {
-    await updateConfigOption(action as OptionName);
+    await updateConfigOption(action as OptionName, config);
   } else {
     clack.outro(`Error: Unknown action "${action}".`);
     process.exit(1);

--- a/packages/cli/src/commands/config/option.ts
+++ b/packages/cli/src/commands/config/option.ts
@@ -1,9 +1,9 @@
 import { readConfigFile, writeConfigFile, optionMap, type OptionName, configPath } from '@wp-tester/config';
 import * as clack from '../../cli/theme';
 
-export async function updateConfigOption(optionName: OptionName): Promise<void> {
+export async function updateConfigOption(optionName: OptionName, configFilePathArg?: string): Promise<void> {
   try {
-    const configFilePath = configPath();
+    const configFilePath = configFilePathArg || configPath();
     const config = await readConfigFile(configFilePath);
 
     const option = optionMap[optionName];

--- a/packages/cli/src/commands/test/runner.ts
+++ b/packages/cli/src/commands/test/runner.ts
@@ -196,6 +196,11 @@ export const runTests = async (
     const resolvedPath = getConfigPath(finalConfigPath);
     clack.log.error(`Config file not found: ${resolvedPath}`);
 
+    // In non-interactive environments (like CI), exit immediately with error
+    if (!process.stdin.isTTY || !process.stdout.isTTY) {
+      process.exit(1);
+    }
+
     const newPath = await clack.text({
       message: "Enter the correct path to your config file:",
       placeholder: "./wp-tester.json",

--- a/packages/config/src/options/ci.ts
+++ b/packages/config/src/options/ci.ts
@@ -282,7 +282,6 @@ on:
 
 jobs:
   test:
-    name: ${workflowName}
     runs-on: ubuntu-latest
 
     steps:

--- a/packages/config/src/options/ci.ts
+++ b/packages/config/src/options/ci.ts
@@ -12,10 +12,13 @@ const WORKFLOW_PATH = ".github/workflows/wp-tester.yml";
  * Workflow configuration options
  */
 interface WorkflowConfig {
+  workflowName: string;
   branches: string[];
   nodeVersion: string;
   enableCaching: boolean;
   wpTesterArgs: string;
+  enableComposerInstall: boolean;
+  composerWorkingDir: string;
 }
 
 /**
@@ -50,6 +53,56 @@ function getGitRoot(projectPath: string): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Detect the composer.json file path
+ * Searches in the project directory and its parents up to git root
+ * Returns the absolute path to composer.json file
+ */
+async function detectComposerWorkingDir(
+  config: WPTesterConfig,
+  configPath?: string,
+  gitRoot?: string
+): Promise<string | null> {
+  const projectPath = getProjectDir(config, configPath);
+
+  // Try project path first
+  try {
+    const composerPath = join(projectPath, "composer.json");
+    await access(composerPath);
+    return composerPath;
+  } catch {
+    // composer.json not in project path, try parent directories
+  }
+
+  // Search parent directories up to git root
+  let currentPath = projectPath;
+  const maxDepth = 10; // Prevent infinite loops
+  let depth = 0;
+
+  while (depth < maxDepth) {
+    const parentPath = dirname(currentPath);
+
+    // Stop if we've reached the root or gone above git root
+    if (parentPath === currentPath ||
+        (gitRoot && !parentPath.startsWith(gitRoot))) {
+      break;
+    }
+
+    try {
+      const composerPath = join(parentPath, "composer.json");
+      await access(composerPath);
+      return composerPath;
+    } catch {
+      // Continue searching
+    }
+
+    currentPath = parentPath;
+    depth++;
+  }
+
+  return null;
 }
 
 /**
@@ -104,10 +157,14 @@ function detectDefaultBranch(projectPath: string): string {
 function extractConfigFromWorkflow(content: string): Partial<WorkflowConfig> {
   const config: Partial<WorkflowConfig> = {};
 
+  // Extract workflow name
+  const nameMatch = content.match(/^name:\s*(.+)$/m);
+  if (nameMatch) {
+    config.workflowName = nameMatch[1].trim();
+  }
+
   // Extract branches
-  const branchMatch = content.match(
-    /branches:\s*\[([^\]]+)\]/
-  );
+  const branchMatch = content.match(/branches:\s*\[([^\]]+)\]/);
   if (branchMatch) {
     config.branches = branchMatch[1]
       .split(",")
@@ -124,12 +181,24 @@ function extractConfigFromWorkflow(content: string): Partial<WorkflowConfig> {
   // Check if caching is enabled
   config.enableCaching = content.includes("actions/cache@");
 
-  // Extract wp-tester args
+  // Check if composer install is enabled
+  config.enableComposerInstall = content.includes("composer install");
+
+  // Extract composer working directory
+  const composerWorkingDirMatch = content.match(
+    /composer install.*?\n\s*working-directory:\s*(.+)/,
+  );
+  if (composerWorkingDirMatch) {
+    config.composerWorkingDir = composerWorkingDirMatch[1].trim();
+  }
+
+  // Extract wp-tester args (can be spread across multiple lines in YAML)
   const argsMatch = content.match(
-    /npx\s+(?:@wp-tester\/cli|wp-tester)(?:@\S+)?\s+test\s*(.*?)(?:\s*\$\{\{|$)/m,
+    /npx\s+(?:@wp-tester\/cli|wp-tester)(?:@\S+)?\s+test\s*([\s\S]*?)(?:\$\{\{|working-directory:)/,
   );
   if (argsMatch && argsMatch[1]) {
-    config.wpTesterArgs = argsMatch[1].trim();
+    // Clean up captured text - collapse whitespace and remove newlines
+    config.wpTesterArgs = argsMatch[1].replace(/\s+/g, ' ').trim();
   }
 
   return config;
@@ -139,7 +208,15 @@ function extractConfigFromWorkflow(content: string): Partial<WorkflowConfig> {
  * Generate the GitHub Action workflow content
  */
 function generateWorkflowContent(config: WorkflowConfig): string {
-  const { branches, nodeVersion, enableCaching, wpTesterArgs } = config;
+  const {
+    workflowName,
+    branches,
+    nodeVersion,
+    enableCaching,
+    wpTesterArgs,
+    enableComposerInstall,
+    composerWorkingDir,
+  } = config;
 
   // Clean up args - split by whitespace for multi-line formatting
   const argsArray = wpTesterArgs
@@ -161,7 +238,23 @@ function generateWorkflowContent(config: WorkflowConfig): string {
 `
     : "";
 
-  return `# WP Tester - WordPress Testing Workflow
+  const composerStep = enableComposerInstall
+    ? `
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist
+        working-directory: ${composerWorkingDir}
+`
+    : "";
+
+  // Add working directory to wp-tester step if composer is in a subdirectory
+  const wpTesterWorkingDir =
+    composerWorkingDir !== "."
+      ? `\n        working-directory: ${composerWorkingDir}`
+      : "";
+
+  return `name: ${workflowName}
+
+# WP Tester - WordPress Testing Workflow
 # This workflow runs wp-tester to test your WordPress plugin/theme
 #
 # For more information, see: https://github.com/bgrgicak/wp-tester
@@ -174,8 +267,6 @@ function generateWorkflowContent(config: WorkflowConfig): string {
 # To customize:
 # - Add arguments like --test=phpunit or --failed-only
 # - See 'npx wp-tester --help' for all available options
-
-name: WP Tester
 
 on:
   push:
@@ -191,7 +282,7 @@ on:
 
 jobs:
   test:
-    name: WP Tester
+    name: ${workflowName}
     runs-on: ubuntu-latest
 
     steps:
@@ -202,40 +293,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '${nodeVersion}'
-${cacheStep}
+${cacheStep}${composerStep}
       - name: Run WP Tester
         run: >
           npx @wp-tester/cli@latest test${argsArray.length > 0 ? `\n          ${argsArray.join("\n          ")}` : ""}
-          \${{ github.event.inputs.wp-tester-args }}
+          \${{ github.event.inputs.wp-tester-args }}${wpTesterWorkingDir}
 `;
 }
 
-
-/**
- * Check if workflow file already exists
- */
-async function workflowExists(projectPath: string): Promise<boolean> {
-  try {
-    await access(join(projectPath, WORKFLOW_PATH));
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Read existing workflow file
- */
-async function readExistingWorkflow(
-  projectPath: string
-): Promise<string | null> {
-  try {
-    const content = await readFile(join(projectPath, WORKFLOW_PATH), "utf8");
-    return content;
-  } catch {
-    return null;
-  }
-}
 
 /**
  * Display success message with workflow details
@@ -251,11 +316,14 @@ function displaySuccessMessage(
       : `Triggers on: ${config.branches.join(", ")}`;
 
   const cacheInfo = config.enableCaching ? " with caching" : "";
+  const composerInfo = config.enableComposerInstall
+    ? `\nComposer dependencies will be installed from: ${config.composerWorkingDir}`
+    : "";
 
   const message = `${pc.cyan(relativePath)}
 
 ${branchInfo}
-Node.js ${config.nodeVersion}${cacheInfo}
+Node.js ${config.nodeVersion}${cacheInfo}${composerInfo}
 You can also trigger it manually from GitHub Actions.`;
 
   clack.note(message, pc.green("✓ GitHub Action created successfully!"));
@@ -305,49 +373,92 @@ export async function ciOption(
     }
   }
 
-  // Get the git root directory - this is where the workflow should be stored
-  const gitRoot = getGitRoot(projectPath);
-  const workflowBasePath = gitRoot || projectPath;
-
-  // Check if user wants to set up CI
+  // If running during setup (not via direct command), ask if user wants to setup CI
   if (!skipPrompt) {
-    const setupCI = await clack.select({
-      message:
-        "Would you like to create a GitHub Action for automated testing?",
-      options: [
-        {
-          value: true,
-          label: "Yes",
-          hint: "Create .github/workflows/wp-tester.yml",
-        },
-        { value: false, label: "No", hint: "Skip CI setup" },
-      ],
+    const setupCI = await clack.confirm({
+      message: "Do you want to setup CI?",
       initialValue: true,
     });
 
-    if (clack.isCancel(setupCI)) {
-      clack.cancel("Setup cancelled.");
-      process.exit(0);
-    }
-
-    if (!setupCI) {
+    if (clack.isCancel(setupCI) || !setupCI) {
+      clack.log.info("Skipping CI setup.");
       return config;
     }
   }
 
+  // Get the git root directory - this is where the workflow should be stored
+  const gitRoot = getGitRoot(projectPath);
+  const workflowBasePath = gitRoot || projectPath;
+
+  // Default workflow path
+  const defaultWorkflowPath = join(workflowBasePath, WORKFLOW_PATH);
+  let customWorkflowPath: string | null = null;
+
+  // Ask for workflow path
+  const workflowPathInput = await clack.text({
+    message: "GitHub Action workflow path",
+    placeholder: defaultWorkflowPath,
+    validate: (value) => {
+      if (value && value.trim().length > 0) {
+        // Check if path looks valid (basic validation)
+        if (!value.includes(".yml") && !value.includes(".yaml")) {
+          return "Workflow file should have .yml or .yaml extension";
+        }
+      }
+      return undefined;
+    },
+  });
+
+  if (clack.isCancel(workflowPathInput)) {
+    clack.cancel("Setup cancelled.");
+    process.exit(0);
+  }
+
+  // If empty, use default path
+  if (!workflowPathInput || workflowPathInput.trim().length === 0) {
+    customWorkflowPath = null;
+  } else if (workflowPathInput !== defaultWorkflowPath) {
+    // Store custom path if different from default
+    customWorkflowPath = workflowPathInput;
+  }
+
+  const detectedComposerDir = await detectComposerWorkingDir(
+    config,
+    configPath,
+    workflowBasePath,
+  );
+  const usesComposer = detectedComposerDir !== null;
+
   // Default configuration
   let workflowConfig: WorkflowConfig = {
+    workflowName: "WP Tester",
     branches: [detectDefaultBranch(workflowBasePath)],
     nodeVersion: "20",
     enableCaching: true,
     wpTesterArgs: "",
+    enableComposerInstall: usesComposer,
+    composerWorkingDir: ".",
   };
 
-  // Check if workflow already exists
-  const exists = await workflowExists(workflowBasePath);
+  // Determine the actual workflow path to use
+  const workflowPath = customWorkflowPath || defaultWorkflowPath;
+
+  // Check if workflow already exists at the target path
+  let exists = false;
+  try {
+    await access(workflowPath);
+    exists = true;
+  } catch {
+    exists = false;
+  }
 
   if (exists) {
-    const existingContent = await readExistingWorkflow(workflowBasePath);
+    let existingContent: string | null = null;
+    try {
+      existingContent = await readFile(workflowPath, "utf8");
+    } catch {
+      existingContent = null;
+    }
     if (existingContent) {
       const extracted = extractConfigFromWorkflow(existingContent);
       workflowConfig = {
@@ -359,7 +470,7 @@ export async function ciOption(
     }
 
     const overwrite = await clack.select({
-      message: `${WORKFLOW_PATH} already exists. What would you like to do?`,
+      message: `${relative(process.cwd(), workflowPath) || workflowPath} already exists. What would you like to do?`,
       options: [
         {
           value: "edit",
@@ -388,13 +499,36 @@ export async function ciOption(
 
     if (overwrite === "overwrite") {
       workflowConfig = {
+        ...workflowConfig,
+        workflowName: "WP Tester",
         branches: [detectDefaultBranch(workflowBasePath)],
         nodeVersion: "20",
         enableCaching: true,
         wpTesterArgs: "",
+        composerWorkingDir: ".",
       };
     }
   }
+
+  // Configure workflow name
+  const workflowName = await clack.text({
+    message: "Workflow name:",
+    initialValue: workflowConfig.workflowName,
+    placeholder: "WP Tester",
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Workflow name is required";
+      }
+      return undefined;
+    },
+  });
+
+  if (clack.isCancel(workflowName)) {
+    clack.cancel("Setup cancelled.");
+    process.exit(0);
+  }
+
+  workflowConfig.workflowName = workflowName.trim();
 
   // Configure branches
   const branchInput = await clack.text({
@@ -450,6 +584,62 @@ export async function ciOption(
 
   workflowConfig.enableCaching = enableCaching;
 
+  // Check if Composer is used
+  if (usesComposer) {
+    const enableComposerInstall = await clack.confirm({
+      message: "Install Composer dependencies before running tests?",
+      initialValue: workflowConfig.enableComposerInstall,
+    });
+
+    if (clack.isCancel(enableComposerInstall)) {
+      clack.cancel("Setup cancelled.");
+      process.exit(0);
+    }
+
+    if (enableComposerInstall) {
+      workflowConfig.enableComposerInstall = true;
+
+      // Calculate the initial value - reconstruct full path from stored config or use detected path
+      const initialComposerPath =
+        workflowConfig.composerWorkingDir !== "."
+          ? join(
+              workflowBasePath,
+              workflowConfig.composerWorkingDir,
+              "composer.json",
+            )
+          : detectedComposerDir;
+
+      // Always ask for the composer.json file path, with the detected path as default
+      const composerJsonPath = await clack.text({
+        message: "Path to composer.json file:",
+        initialValue: initialComposerPath || detectedComposerDir || "",
+        placeholder: `Detected: ${detectedComposerDir}`,
+        validate: (value) => {
+          if (!value || value.trim().length === 0) {
+            return "Path to composer.json is required";
+          }
+          if (!value.endsWith("composer.json")) {
+            return "Path must end with composer.json";
+          }
+          return undefined;
+        },
+      });
+
+      if (clack.isCancel(composerJsonPath)) {
+        clack.cancel("Setup cancelled.");
+        process.exit(0);
+      }
+
+      // Extract the directory from the composer.json path for the workflow
+      const composerDir = dirname(composerJsonPath.trim());
+      // Calculate relative path from git root
+      workflowConfig.composerWorkingDir =
+        relative(workflowBasePath, composerDir) || ".";
+    } else {
+      workflowConfig.enableComposerInstall = false;
+    }
+  }
+
   // Show help for wp-tester arguments
   displayConfigHelp();
 
@@ -486,15 +676,14 @@ export async function ciOption(
   }
 
   // Create directory and file with spinner
-  const workflowFullPath = join(workflowBasePath, WORKFLOW_PATH);
-  const workflowDir = dirname(workflowFullPath);
+  const workflowDir = dirname(workflowPath);
 
   const spinner = clack.spinner();
   spinner.start("Creating workflow file...");
 
   try {
     await mkdir(workflowDir, { recursive: true });
-    await writeFile(workflowFullPath, workflowContent, "utf8");
+    await writeFile(workflowPath, workflowContent, "utf8");
     spinner.stop("Workflow file created!");
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
@@ -504,7 +693,7 @@ export async function ciOption(
   }
 
   // Display success message
-  displaySuccessMessage(workflowFullPath, workflowConfig);
+  displaySuccessMessage(workflowPath, workflowConfig);
 
   return config;
 }

--- a/packages/config/src/options/ci.ts
+++ b/packages/config/src/options/ci.ts
@@ -1,3 +1,11 @@
+/**
+ * CI Configuration Module
+ *
+ * Handles GitHub Actions workflow generation for wp-tester.
+ * Automatically detects git repository settings, composer dependencies,
+ * and provides an interactive setup for creating/updating CI workflows.
+ */
+
 import type { WPTesterConfig } from "../types";
 import * as clack from "@clack/prompts";
 import { mkdir, writeFile, access, readFile } from "fs/promises";
@@ -23,6 +31,8 @@ interface WorkflowConfig {
 
 /**
  * Check if the project is a git repository
+ * @param projectPath - Directory to check
+ * @returns true if directory is a git repository
  */
 function isGitRepo(projectPath: string): boolean {
   try {
@@ -107,6 +117,9 @@ async function detectComposerWorkingDir(
 
 /**
  * Detect the default branch name from git
+ * Tries remote HEAD, then checks for common branch names (main, master, trunk)
+ * @param projectPath - Git repository path
+ * @returns Detected branch name, defaults to "main"
  */
 function detectDefaultBranch(projectPath: string): string {
   try {
@@ -152,7 +165,10 @@ function detectDefaultBranch(projectPath: string): string {
 
 
 /**
- * Extract configuration from existing workflow
+ * Extract configuration from existing workflow file
+ * Parses YAML content to preserve user settings when updating
+ * @param content - Raw workflow file content
+ * @returns Parsed workflow configuration
  */
 function extractConfigFromWorkflow(content: string): Partial<WorkflowConfig> {
   const config: Partial<WorkflowConfig> = {};
@@ -206,6 +222,9 @@ function extractConfigFromWorkflow(content: string): Partial<WorkflowConfig> {
 
 /**
  * Generate the GitHub Action workflow content
+ * Creates a complete workflow YAML with all configured options
+ * @param config - Workflow configuration
+ * @returns Complete workflow file content
  */
 function generateWorkflowContent(config: WorkflowConfig): string {
   const {
@@ -303,6 +322,8 @@ ${cacheStep}${composerStep}
 
 /**
  * Display success message with workflow details
+ * @param workflowPath - Path to created workflow file
+ * @param config - Workflow configuration used
  */
 function displaySuccessMessage(
   workflowPath: string,

--- a/packages/config/src/options/index.ts
+++ b/packages/config/src/options/index.ts
@@ -33,7 +33,7 @@ const optionMapInternal = {
   },
   'ci': {
     handler: ciOption,
-    getContext: (configPath: string) => ({ configPath }),
+    getContext: (configPath: string) => ({ configPath, skipPrompt: true }),
   }
 } satisfies Record<string, ConfigOptionDefinition>;
 

--- a/packages/config/src/path-utils.ts
+++ b/packages/config/src/path-utils.ts
@@ -119,7 +119,7 @@ export function normalizeConfigPath(configPath: string): string {
  * @returns Directory path where the config file is located
  */
 export function getConfigDir(configPath: string): string {
-  return dirname(getConfigPath(configPath));
+  return dirname(normalizeConfigPath(configPath));
 }
 
 /**

--- a/packages/phpunit/src/wordpress-test-lib.ts
+++ b/packages/phpunit/src/wordpress-test-lib.ts
@@ -33,6 +33,14 @@ function calculateFileChecksum(filePath: string): string {
 }
 
 /**
+ * Strip pre-release suffixes from version strings
+ * Converts "6.9.1-RC1" to "6.9.1", "6.9.0-beta1" to "6.9.0", etc.
+ */
+function stripPreReleaseSuffix(version: string): string {
+  return version.replace(/-(RC|beta|alpha|dev)\d*$/i, '');
+}
+
+/**
  * Find the closest matching WordPress test library version tag
  * WordPress might use 6.9, but wordpress-develop uses 6.9.0
  *
@@ -59,14 +67,17 @@ async function findMatchingTag(requestedVersion: string): Promise<string> {
 
     const tags = await response.json() as GitHubTag[];
 
-    // Try exact match first
-    const exactMatch = tags.find(tag => tag.name === requestedVersion);
+    // Strip pre-release suffixes (e.g., -RC1, -beta1) before matching
+    const normalizedVersion = stripPreReleaseSuffix(requestedVersion);
+
+    // Try exact match first (with both original and normalized version)
+    const exactMatch = tags.find(tag => tag.name === requestedVersion || tag.name === normalizedVersion);
     if (exactMatch) {
       return exactMatch.name;
     }
 
     // Parse version to try X.Y.0 pattern
-    const versionMatch = requestedVersion.match(/^(\d+\.\d+)(?:\.(\d+))?$/);
+    const versionMatch = normalizedVersion.match(/^(\d+\.\d+)(?:\.(\d+))?$/);
     if (versionMatch) {
       const [, baseVersion, patch] = versionMatch;
 
@@ -110,9 +121,13 @@ async function findMatchingTag(requestedVersion: string): Promise<string> {
 /**
  * Infer the tag name from a version string when GitHub API is unavailable
  * Converts "6.9" to "6.9.0", keeps "6.4.1" as is
+ * Strips pre-release suffixes (e.g., "6.9.1-RC1" becomes "6.9.1")
  */
 function inferTagName(version: string): string | null {
-  const versionMatch = version.match(/^(\d+\.\d+)(?:\.(\d+))?$/);
+  // Strip pre-release suffixes first
+  const normalizedVersion = stripPreReleaseSuffix(version);
+
+  const versionMatch = normalizedVersion.match(/^(\d+\.\d+)(?:\.(\d+))?$/);
   if (!versionMatch) {
     return null; // Invalid version format
   }
@@ -125,7 +140,7 @@ function inferTagName(version: string): string | null {
   }
 
   // Already has patch version, use as-is
-  return version;
+  return normalizedVersion;
 }
 
 /**

--- a/packages/runtime/tests/version.spec.ts
+++ b/packages/runtime/tests/version.spec.ts
@@ -17,6 +17,8 @@ describe('getWordPressVersion', () => {
         },
       },
       mounts: [],
+      env: {},
+      skip: false,
     };
     playground = await startPlayground(environment);
   }, 180000); // 3 min for WordPress Playground setup
@@ -29,7 +31,7 @@ describe('getWordPressVersion', () => {
 
   it('should detect WordPress version from running instance', async () => {
     const version = await getWordPressVersion(playground.playground);
-    expect(version).toMatch(/^\d+\.\d+(\.\d+)?$/); // Matches X.Y or X.Y.Z
+    expect(version).toMatch(/^\d+\.\d+(\.\d+)?(-[A-Za-z0-9]+)?$/); // Matches X.Y, X.Y.Z, or X.Y.Z-RC1
     expect(version.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

Adds automatic Composer dependency detection to the CI setup and fixes WordPress pre-release version handling, since projects using Composer dependencies required manual workflow configuration. 

## Implementation details

**Composer auto-detection**: CI setup now searches for `composer.json` and prompts to install dependencies. Generates workflow with `composer install` step and correct working directory.

**Pre-release versions**: Strips suffixes like `-RC1`, `-beta1` before matching tags, so `6.9.1-RC1` → `6.9.1`.

**CI improvements**: Exits immediately in non-interactive environments instead of hanging on prompts.

## Testing Instructions

1. Run `npx @wp-tester/cli config ci` in a project with `composer.json`
2. Verify it detects the composer.json location and generates workflow with install step
3. Test with WordPress pre-release version to confirm test library downloads
