### PR TITLE
Remove test status filter support from JSON reporter

### DIFF
--- a/packages/cli/tests/integration/json-reporter.spec.ts
+++ b/packages/cli/tests/integration/json-reporter.spec.ts
@@ -22,11 +22,37 @@ describe('JSON Reporter Integration', { timeout: 120000 }, () => {
     await rm(testDir, { recursive: true, force: true });
   });
 
-  it('should write JSON report file with default outputFile path', async () => {
+  it('should write JSON report file with default outputFile path using empty object', async () => {
     const config: WPTesterConfig = {
       environments: [{ blueprint: { landingPage: '/' } }],
       tests: { wp: true },
       reporters: { json: {} },
+    };
+    await writeFile(configFile, JSON.stringify(config, null, 2));
+
+    await executeTests(configFile);
+
+    // Verify JSON file was created
+    expect(existsSync(jsonOutputFile)).toBe(true);
+
+    // Verify JSON file contains valid CTRF format
+    const content = await readFile(jsonOutputFile, 'utf-8');
+    const report = JSON.parse(content);
+
+    expect(report).toHaveProperty('reportFormat', 'CTRF');
+    expect(report).toHaveProperty('results');
+    expect(report.results).toHaveProperty('summary');
+    expect(report.results).toHaveProperty('tests');
+    expect(report.results.summary).toHaveProperty('tests');
+    expect(report.results.summary).toHaveProperty('passed');
+    expect(report.results.summary).toHaveProperty('failed');
+  });
+
+  it('should write JSON report file with default outputFile path using true shorthand', async () => {
+    const config: WPTesterConfig = {
+      environments: [{ blueprint: { landingPage: '/' } }],
+      tests: { wp: true },
+      reporters: { json: true },
     };
     await writeFile(configFile, JSON.stringify(config, null, 2));
 

--- a/packages/cli/tests/integration/json-reporter.spec.ts
+++ b/packages/cli/tests/integration/json-reporter.spec.ts
@@ -83,30 +83,7 @@ describe('JSON Reporter Integration', { timeout: 120000 }, () => {
     expect(existsSync(jsonOutputFile)).toBe(false);
   });
 
-  it('should filter JSON output to exclude failed tests', async () => {
-    const config: WPTesterConfig = {
-      environments: [{ blueprint: { landingPage: '/' } }],
-      tests: { wp: true },
-      reporters: { json: { failed: false, passed: true, skipped: true } },
-    };
-    await writeFile(configFile, JSON.stringify(config, null, 2));
-
-    await executeTests(configFile);
-
-    const content = await readFile(jsonOutputFile, 'utf-8');
-    const report = JSON.parse(content);
-
-    // Filtered count should match passed + skipped
-    const expectedCount = report.results.summary.passed + report.results.summary.skipped;
-    expect(report.results.tests.length).toBe(expectedCount);
-
-    // No failed tests should be in the output
-    for (const test of report.results.tests) {
-      expect(test.status).not.toBe('failed');
-    }
-  });
-
-  it('should include all tests when no filters are specified', async () => {
+  it('should always include all tests in JSON output regardless of filter settings', async () => {
     const config: WPTesterConfig = {
       environments: [{ blueprint: { landingPage: '/' } }],
       tests: { wp: true },

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -88,6 +88,8 @@ export async function resolveConfig(
   }
 
   // Resolve JSON reporter if configured
+  // Note: JSON reporter only has outputFile option - filter options are not supported
+  // (filter only affects console display, not JSON output)
   const inputJson = resolvedConfig.reporters?.json;
   if (inputJson) {
     // Get config directory for default output path
@@ -95,7 +97,6 @@ export async function resolveConfig(
     const defaultOutputFile = join(configDir, "wp-tester-results.json");
 
     const resolvedJson: ResolvedJsonReporterOptions = {
-      ...inputJson,
       outputFile: inputJson.outputFile
         ? resolveAbsolute(inputJson.outputFile, configDir)
         : defaultOutputFile,

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -91,15 +91,18 @@ export async function resolveConfig(
   // Note: JSON reporter only has outputFile option - filter options are not supported
   // (filter only affects console display, not JSON output)
   const inputJson = resolvedConfig.reporters?.json;
-  if (inputJson) {
+  if (inputJson === true || (typeof inputJson === 'object' && inputJson !== null)) {
     // Get config directory for default output path
     const configDir = configPath ? dirname(configPath) : projectDir;
     const defaultOutputFile = join(configDir, "wp-tester-results.json");
 
+    // Handle boolean shorthand: true or {} both use default outputFile
+    const outputFile = inputJson === true || !inputJson.outputFile
+      ? defaultOutputFile
+      : resolveAbsolute(inputJson.outputFile, configDir);
+
     const resolvedJson: ResolvedJsonReporterOptions = {
-      outputFile: inputJson.outputFile
-        ? resolveAbsolute(inputJson.outputFile, configDir)
-        : defaultOutputFile,
+      outputFile,
     };
     reporters.json = resolvedJson;
   }

--- a/packages/config/src/resolved-types.ts
+++ b/packages/config/src/resolved-types.ts
@@ -3,8 +3,11 @@ import type { Mount, Tests, Environment, WPTesterConfig, TestMode, ProjectType, 
 
 /**
  * Resolved JSON reporter options with required outputFile.
+ *
+ * Note: The JSON reporter always includes all tests in the output
+ * regardless of any filter settings.
  */
-export interface ResolvedJsonReporterOptions extends BaseReporterOptions {
+export interface ResolvedJsonReporterOptions {
   /** Absolute path where the JSON report file will be written */
   outputFile: string;
 }

--- a/packages/config/src/schema.json
+++ b/packages/config/src/schema.json
@@ -43,7 +43,7 @@
     },
     "ArrayBuffer": {
       "properties": {
-        "__@toStringTag@506": {
+        "__@toStringTag@570": {
           "type": "string"
         },
         "byteLength": {
@@ -51,7 +51,7 @@
         }
       },
       "required": [
-        "__@toStringTag@506",
+        "__@toStringTag@570",
         "byteLength"
       ],
       "type": "object"
@@ -397,7 +397,7 @@
                                   "BYTES_PER_ELEMENT": {
                                     "type": "number"
                                   },
-                                  "__@toStringTag@506": {
+                                  "__@toStringTag@570": {
                                     "const": "Uint8Array",
                                     "type": "string"
                                   },
@@ -416,7 +416,7 @@
                                 },
                                 "required": [
                                   "BYTES_PER_ELEMENT",
-                                  "__@toStringTag@506",
+                                  "__@toStringTag@570",
                                   "buffer",
                                   "byteLength",
                                   "byteOffset",
@@ -1393,7 +1393,7 @@
                     "BYTES_PER_ELEMENT": {
                       "type": "number"
                     },
-                    "__@toStringTag@506": {
+                    "__@toStringTag@570": {
                       "const": "Uint8Array",
                       "type": "string"
                     },
@@ -1412,7 +1412,7 @@
                   },
                   "required": [
                     "BYTES_PER_ELEMENT",
-                    "__@toStringTag@506",
+                    "__@toStringTag@570",
                     "buffer",
                     "byteLength",
                     "byteOffset",
@@ -1654,7 +1654,7 @@
                         "BYTES_PER_ELEMENT": {
                           "type": "number"
                         },
-                        "__@toStringTag@506": {
+                        "__@toStringTag@570": {
                           "const": "Uint8Array",
                           "type": "string"
                         },
@@ -1673,7 +1673,7 @@
                       },
                       "required": [
                         "BYTES_PER_ELEMENT",
-                        "__@toStringTag@506",
+                        "__@toStringTag@570",
                         "buffer",
                         "byteLength",
                         "byteOffset",
@@ -1862,7 +1862,7 @@
                         "BYTES_PER_ELEMENT": {
                           "type": "number"
                         },
-                        "__@toStringTag@506": {
+                        "__@toStringTag@570": {
                           "const": "Uint8Array",
                           "type": "string"
                         },
@@ -1881,7 +1881,7 @@
                       },
                       "required": [
                         "BYTES_PER_ELEMENT",
-                        "__@toStringTag@506",
+                        "__@toStringTag@570",
                         "buffer",
                         "byteLength",
                         "byteOffset",
@@ -2075,7 +2075,7 @@
                         "BYTES_PER_ELEMENT": {
                           "type": "number"
                         },
-                        "__@toStringTag@506": {
+                        "__@toStringTag@570": {
                           "const": "Uint8Array",
                           "type": "string"
                         },
@@ -2094,7 +2094,7 @@
                       },
                       "required": [
                         "BYTES_PER_ELEMENT",
-                        "__@toStringTag@506",
+                        "__@toStringTag@570",
                         "buffer",
                         "byteLength",
                         "byteOffset",
@@ -2283,7 +2283,7 @@
                         "BYTES_PER_ELEMENT": {
                           "type": "number"
                         },
-                        "__@toStringTag@506": {
+                        "__@toStringTag@570": {
                           "const": "Uint8Array",
                           "type": "string"
                         },
@@ -2302,7 +2302,7 @@
                       },
                       "required": [
                         "BYTES_PER_ELEMENT",
-                        "__@toStringTag@506",
+                        "__@toStringTag@570",
                         "buffer",
                         "byteLength",
                         "byteOffset",
@@ -2419,12 +2419,12 @@
       "type": "object"
     },
     "JsonReporterOptions": {
-      "description": "JSON reporter configuration options. The JSON reporter always includes all tests in the output regardless of any filter settings.",
+      "description": "JSON reporter configuration options.\n\nNote: Unlike the default reporter, the JSON reporter always includes all tests\nin the output regardless of any filter settings. Filter options only affect\nconsole display.",
       "properties": {
         "outputFile": {
-          "description": "Path where the JSON report file should be written. Defaults to wp-tester-results.json in the config directory.",
-          "type": "string",
-          "default": "wp-tester-results.json"
+          "default": "wp-tester-results.json",
+          "description": "Path where the JSON report file should be written.\nRelative paths are resolved from the config file location.",
+          "type": "string"
         }
       },
       "type": "object"
@@ -2511,7 +2511,7 @@
                 "BYTES_PER_ELEMENT": {
                   "type": "number"
                 },
-                "__@toStringTag@506": {
+                "__@toStringTag@570": {
                   "const": "Uint8Array",
                   "type": "string"
                 },
@@ -2530,7 +2530,7 @@
               },
               "required": [
                 "BYTES_PER_ELEMENT",
-                "__@toStringTag@506",
+                "__@toStringTag@570",
                 "buffer",
                 "byteLength",
                 "byteOffset",
@@ -2596,7 +2596,7 @@
                 "BYTES_PER_ELEMENT": {
                   "type": "number"
                 },
-                "__@toStringTag@506": {
+                "__@toStringTag@570": {
                   "const": "Uint8Array",
                   "type": "string"
                 },
@@ -2615,7 +2615,7 @@
               },
               "required": [
                 "BYTES_PER_ELEMENT",
-                "__@toStringTag@506",
+                "__@toStringTag@570",
                 "buffer",
                 "byteLength",
                 "byteOffset",
@@ -2731,8 +2731,15 @@
           "description": "Default console reporter options.\nUse `true` to enable with defaults, or an object for custom options."
         },
         "json": {
-          "$ref": "#/definitions/JsonReporterOptions",
-          "description": "JSON file reporter options"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/JsonReporterOptions"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "description": "JSON file reporter options.\nUse `true` to enable with defaults, or an object for custom options."
         }
       },
       "type": "object"
@@ -2916,10 +2923,10 @@
     },
     "SharedArrayBuffer": {
       "properties": {
-        "__@species@590": {
+        "__@species@614": {
           "$ref": "#/definitions/SharedArrayBuffer"
         },
-        "__@toStringTag@506": {
+        "__@toStringTag@570": {
           "const": "SharedArrayBuffer",
           "type": "string"
         },
@@ -2928,8 +2935,8 @@
         }
       },
       "required": [
-        "__@species@590",
-        "__@toStringTag@506",
+        "__@species@614",
+        "__@toStringTag@570",
         "byteLength"
       ],
       "type": "object"
@@ -3012,7 +3019,7 @@
                         "BYTES_PER_ELEMENT": {
                           "type": "number"
                         },
-                        "__@toStringTag@506": {
+                        "__@toStringTag@570": {
                           "const": "Uint8Array",
                           "type": "string"
                         },
@@ -3031,7 +3038,7 @@
                       },
                       "required": [
                         "BYTES_PER_ELEMENT",
-                        "__@toStringTag@506",
+                        "__@toStringTag@570",
                         "buffer",
                         "byteLength",
                         "byteOffset",
@@ -3255,7 +3262,7 @@
                 "BYTES_PER_ELEMENT": {
                   "type": "number"
                 },
-                "__@toStringTag@506": {
+                "__@toStringTag@570": {
                   "const": "Uint8Array",
                   "type": "string"
                 },
@@ -3274,7 +3281,7 @@
               },
               "required": [
                 "BYTES_PER_ELEMENT",
-                "__@toStringTag@506",
+                "__@toStringTag@570",
                 "buffer",
                 "byteLength",
                 "byteOffset",
@@ -3315,7 +3322,7 @@
                         "BYTES_PER_ELEMENT": {
                           "type": "number"
                         },
-                        "__@toStringTag@506": {
+                        "__@toStringTag@570": {
                           "const": "Uint8Array",
                           "type": "string"
                         },
@@ -3334,7 +3341,7 @@
                       },
                       "required": [
                         "BYTES_PER_ELEMENT",
-                        "__@toStringTag@506",
+                        "__@toStringTag@570",
                         "buffer",
                         "byteLength",
                         "byteOffset",

--- a/packages/config/src/schema.json
+++ b/packages/config/src/schema.json
@@ -2419,37 +2419,12 @@
       "type": "object"
     },
     "JsonReporterOptions": {
-      "description": "JSON reporter configuration options",
+      "description": "JSON reporter configuration options. The JSON reporter always includes all tests in the output regardless of any filter settings.",
       "properties": {
-        "failed": {
-          "default": false,
-          "description": "Show failed tests in output",
-          "type": "boolean"
-        },
-        "other": {
-          "default": false,
-          "description": "Show other test statuses in output",
-          "type": "boolean"
-        },
         "outputFile": {
           "description": "Path where the JSON report file should be written. Defaults to wp-tester-results.json in the config directory.",
           "type": "string",
           "default": "wp-tester-results.json"
-        },
-        "passed": {
-          "default": false,
-          "description": "Show passed tests in output",
-          "type": "boolean"
-        },
-        "pending": {
-          "default": false,
-          "description": "Show pending tests in output",
-          "type": "boolean"
-        },
-        "skipped": {
-          "default": false,
-          "description": "Show skipped tests in output",
-          "type": "boolean"
         }
       },
       "type": "object"

--- a/packages/config/src/wp-tester-config.ts
+++ b/packages/config/src/wp-tester-config.ts
@@ -184,9 +184,13 @@ export interface BaseReporterOptions {
 export type DefaultReporterOptions = BaseReporterOptions;
 
 /**
- * JSON reporter configuration options
+ * JSON reporter configuration options.
+ *
+ * Note: Unlike the default reporter, the JSON reporter always includes all tests
+ * in the output regardless of any filter settings. Filter options only affect
+ * console display.
  */
-export interface JsonReporterOptions extends BaseReporterOptions {
+export interface JsonReporterOptions {
   /**
    * Path where the JSON report file should be written.
    * Relative paths are resolved from the config file location.

--- a/packages/config/src/wp-tester-config.ts
+++ b/packages/config/src/wp-tester-config.ts
@@ -217,9 +217,10 @@ export interface Reporters {
   default?: boolean | DefaultReporterOptions;
 
   /**
-   * JSON file reporter options
+   * JSON file reporter options.
+   * Use `true` to enable with defaults, or an object for custom options.
    */
-  json?: JsonReporterOptions;
+  json?: boolean | JsonReporterOptions;
 }
 
 /**

--- a/packages/config/tests/json-reporter.spec.ts
+++ b/packages/config/tests/json-reporter.spec.ts
@@ -78,28 +78,6 @@ describe('JSON Reporter Config Resolution', () => {
     expect(resolved.reporters.json?.outputFile).toBe(absolutePath);
   });
 
-  it('should preserve filter options when resolving json reporter', async () => {
-    const config: WPTesterConfig = {
-      ...baseConfig,
-      reporters: {
-        json: {
-          outputFile: 'results.json',
-          passed: true,
-          failed: true,
-          skipped: false,
-        },
-      },
-    };
-    await writeFile(configFile, JSON.stringify(config, null, 2));
-
-    const resolved = await resolveConfig(configFile);
-
-    expect(resolved.reporters.json).toBeDefined();
-    expect(resolved.reporters.json?.passed).toBe(true);
-    expect(resolved.reporters.json?.failed).toBe(true);
-    expect(resolved.reporters.json?.skipped).toBe(false);
-  });
-
   it('should resolve json reporter alongside default reporter', async () => {
     const config: WPTesterConfig = {
       ...baseConfig,

--- a/packages/config/tests/json-reporter.spec.ts
+++ b/packages/config/tests/json-reporter.spec.ts
@@ -34,7 +34,7 @@ describe('JSON Reporter Config Resolution', () => {
     expect(resolved.reporters.json).toBeUndefined();
   });
 
-  it('should resolve json reporter with default outputFile', async () => {
+  it('should resolve json reporter with default outputFile when using empty object', async () => {
     const config: WPTesterConfig = {
       ...baseConfig,
       reporters: { json: {} },
@@ -47,6 +47,33 @@ describe('JSON Reporter Config Resolution', () => {
     expect(resolved.reporters.json?.outputFile).toBe(
       join(configDir, 'wp-tester-results.json')
     );
+  });
+
+  it('should resolve json reporter with default outputFile when using true shorthand', async () => {
+    const config: WPTesterConfig = {
+      ...baseConfig,
+      reporters: { json: true },
+    };
+    await writeFile(configFile, JSON.stringify(config, null, 2));
+
+    const resolved = await resolveConfig(configFile);
+
+    expect(resolved.reporters.json).toBeDefined();
+    expect(resolved.reporters.json?.outputFile).toBe(
+      join(configDir, 'wp-tester-results.json')
+    );
+  });
+
+  it('should not enable json reporter when using false', async () => {
+    const config: WPTesterConfig = {
+      ...baseConfig,
+      reporters: { json: false },
+    };
+    await writeFile(configFile, JSON.stringify(config, null, 2));
+
+    const resolved = await resolveConfig(configFile);
+
+    expect(resolved.reporters.json).toBeUndefined();
   });
 
   it('should resolve json reporter with custom relative outputFile', async () => {

--- a/packages/results/src/streaming.spec.ts
+++ b/packages/results/src/streaming.spec.ts
@@ -586,7 +586,7 @@ describe("StreamingReporter", () => {
     expect(output).toContain("1 failed");
   });
 
-  it("should filter tests array but show accurate totals in summary", () => {
+  it("should always include all tests in report regardless of filter settings", () => {
     const filteredWriter = new MockWriter();
     const filteredReporter = new StreamingReporter({
       writer: filteredWriter,
@@ -611,12 +611,11 @@ describe("StreamingReporter", () => {
 
     const report = filteredReporter.getReport();
 
-    // Tests array should only contain failed tests (filtered based on filter settings)
-    expect(report.results.tests).toHaveLength(1);
-    expect(report.results.tests[0].name).toBe("Suite::failing test");
-    expect(report.results.tests[0].status).toBe("failed");
+    // Report should contain ALL tests regardless of filter settings
+    // (filter only affects console display, not report output)
+    expect(report.results.tests).toHaveLength(3);
 
-    // Summary should reflect ALL tests for accurate totals
+    // Summary should reflect ALL tests
     expect(report.results.summary.tests).toBe(3);
     expect(report.results.summary.passed).toBe(1);
     expect(report.results.summary.failed).toBe(1);

--- a/packages/results/src/streaming.ts
+++ b/packages/results/src/streaming.ts
@@ -88,15 +88,10 @@ function formatDuration(ms: number): string {
 }
 
 /**
- * Filter options for controlling which test statuses are shown.
+ * Filter options for controlling which test statuses are shown in console output.
  *
- * Filters affect:
- * - Console display: Only matching tests are shown
- * - Report tests array: Only matching tests are included in getReport().results.tests
- * - Summary counts: Always show accurate totals for ALL tests (not filtered)
- *
- * This allows --failed-only to produce a JSON report with only failed tests in the
- * array while still showing accurate total counts in the summary.
+ * Filters only affect console display - the report output from getReport()
+ * always includes all tests regardless of filter settings.
  */
 export interface ReporterFilterOptions {
   /** Show/include passed tests (default: false) */
@@ -1177,25 +1172,19 @@ export class StreamingReporter {
   /**
    * Get the current report in CTRF format
    *
-   * The tests array is filtered based on the reporter's filter options,
-   * but the summary counts reflect ALL tests for accurate totals.
-   * This allows the JSON report to contain only relevant tests while
-   * showing complete statistics.
+   * Returns all tests regardless of filter settings. The filter options
+   * only affect console display, not the report output. This ensures
+   * the JSON report always contains complete test results.
    */
   getReport(): Report {
     const tests: Test[] = [];
 
-    // Collect tests from all files, applying filter to tests array
+    // Collect all tests from all files (no filtering for report output)
     for (const file of this.state.files.values()) {
       for (const suite of file.suites) {
         for (const test of suite.tests) {
           const status: TestStatus =
             test.status === "running" ? "other" : (test.status as TestStatus);
-
-          // Apply filter - only include tests that match filter criteria
-          if (!this.shouldShowStatus(test.status)) {
-            continue;
-          }
 
           const ctrf: Test = {
             name: test.suiteName
@@ -1217,15 +1206,13 @@ export class StreamingReporter {
       }
     }
 
-    // Use actual state counts for accurate totals (includes all tests, even filtered ones)
-    // The tests array is filtered, but the summary reflects the true test counts
     const summary = {
       tests: this.state.totalTests,
       passed: this.state.passedTests,
       failed: this.state.failedTests,
       skipped: this.state.skippedTests,
       pending: this.state.pendingTests,
-      other: 0, // We don't track "other" status in our state
+      other: 0,
       start: this.state.startTime,
       stop: Date.now(),
     };


### PR DESCRIPTION
Simplifies JSON reporter configuration and removes test status filtering from JSON output.
It was originally implemented in this way to enable AI to read test results without taking up too much context, but most AI tools should be able to filter JSON using jq or similar, so the feature isn't actually needed. 
