### PR TITLE
[CLI] Add verbose hint to default reporter and log formatting utilities

### DIFF
--- a/packages/cli/src/commands/test/runner.ts
+++ b/packages/cli/src/commands/test/runner.ts
@@ -3,7 +3,12 @@ import path from 'path';
 import * as clack from '../../cli/theme';
 import { runSmokeTests } from "@wp-tester/smoke-tests";
 import { runPhpunitTests } from "@wp-tester/phpunit";
-import { mergeReports, printSummary, type Report } from "@wp-tester/results";
+import {
+  mergeReports,
+  printSummary,
+  formatHint,
+  type Report,
+} from "@wp-tester/results";
 import type { TestType, ResolvedWPTesterConfig } from "@wp-tester/config";
 import { resolveConfig } from "@wp-tester/config";
 import { validateConfig } from "../config/validate";
@@ -144,7 +149,7 @@ export interface TestResult {
  */
 export const executeTests = async (
   configPath: string,
-  options?: RunTestsOptions
+  options?: RunTestsOptions,
 ): Promise<TestResult> => {
   const { testType, extraArgs, verbose } = options || {};
   const finalConfigPath = await resolveConfigPath(configPath);
@@ -217,8 +222,12 @@ export const executeTests = async (
   const { summary } = mergedReport.results;
   const success = summary.failed === 0;
 
-
   printSummary(summary);
+
+  // Show hint about verbose mode if not already enabled
+  if (!verbose) {
+    console.log(formatHint("Hint: Use --verbose to see the output of all tests"));
+  }
 
   return { success, hasTests: true };
 };

--- a/packages/phpunit/src/runner.ts
+++ b/packages/phpunit/src/runner.ts
@@ -77,7 +77,7 @@ async function runPhpunitTestsForEnvironment(
       return EMPTY_REPORT;
     }
 
-    if (!config.projectPath.vfsPath) {
+    if (!config.projectPath?.vfsPath) {
       console.error(
         `Project type '${config.projectType}' does not support PHPUnit tests`,
       );
@@ -85,8 +85,8 @@ async function runPhpunitTestsForEnvironment(
     }
 
     // Get VFS paths from resolved config
-    const vfsPhpunitConfigPath = config.tests.phpunit!.configPath.vfsPath;
-    const vfsPhpunitPath = config.tests.phpunit!.phpunitPath.vfsPath;
+    const vfsPhpunitConfigPath: string = config.tests.phpunit!.configPath.vfsPath;
+    const vfsPhpunitPath: string = config.tests.phpunit!.phpunitPath.vfsPath;
 
     // Only create WordPress bootstrap in integration mode
     let bootstrapFilePath: string | null = null;
@@ -95,7 +95,7 @@ async function runPhpunitTestsForEnvironment(
       const bootstrapPath = config.tests.phpunit!.bootstrapPath;
 
       // Get VFS path directly from resolved path (or use default if not found)
-      const userBootstrap = bootstrapPath?.vfsPath
+      const userBootstrap: string = bootstrapPath?.vfsPath
         ?? `${config.projectPath.vfsPath}/tests/bootstrap.php`;
 
       // Create a custom bootstrap file that loads WordPress, then user's bootstrap if it exists
@@ -119,7 +119,7 @@ async function runPhpunitTestsForEnvironment(
 
     // Build PHP CLI arguments with environment variables
     // Use TeamCity format for streaming output
-    const cliArgs = [
+    const cliArgs: string[] = [
       "php",
       // Set variables_order to EGPCS to ensure environment variables are accessible.
       // This is required for WordPress test library to access WP_TESTS_DIR via getenv().
@@ -381,9 +381,9 @@ export async function runPhpunitTests(
   let resolvedConfig = { ...config };
   if (phpunitArgs && phpunitArgs.length > 0) {
     // Resolve the additional args before merging
-    const resolvedAdditionalArgs = resolvePhpunitArgs(phpunitArgs, config.projectPath);
-    const configArgs = resolvedConfig.tests.phpunit?.phpunitArgs || [];
-    const mergedArgs = [...configArgs, ...resolvedAdditionalArgs];
+    const resolvedAdditionalArgs: string[] = resolvePhpunitArgs(phpunitArgs, config.projectPath);
+    const configArgs: string[] = resolvedConfig.tests.phpunit?.phpunitArgs || [];
+    const mergedArgs: string[] = [...configArgs, ...resolvedAdditionalArgs];
 
     resolvedConfig = {
       ...resolvedConfig,

--- a/packages/results/src/index.ts
+++ b/packages/results/src/index.ts
@@ -52,6 +52,13 @@ export {
   parseTeamCityOutput,
 } from './teamcity-parser.js';
 export { printSummary, type SummaryOptions } from './summary.js';
+export {
+  formatDuration,
+  formatHint,
+  formatStatusLine,
+  formatSummaryLine,
+  statusSymbols,
+} from './log-formatting.js';
 
 export const EMPTY_REPORT: Report = {
   results: {

--- a/packages/results/src/log-formatting.ts
+++ b/packages/results/src/log-formatting.ts
@@ -1,0 +1,58 @@
+/**
+ * Log Formatting Utilities
+ *
+ * Centralized formatting and styling functions for consistent CLI output.
+ * Uses picocolors for terminal color support.
+ */
+
+import pc from "picocolors";
+
+/**
+ * Format duration in human-readable format
+ */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) {
+    return `${Math.round(ms)}ms`;
+  }
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+/**
+ * Format a dimmed line (used for hints, legends, and other secondary text)
+ * The message should include any prefix (e.g., "Hint:", "Legend:")
+ */
+export function formatHint(message: string): string {
+  return pc.dim(`  ${message}`);
+}
+
+/**
+ * Format test status symbols with colors
+ */
+export const statusSymbols = {
+  passed: pc.green("✓"),
+  failed: pc.red("✗"),
+  skipped: pc.yellow("○"),
+  pending: pc.yellow("◔"),
+  other: pc.gray("◆"),
+} as const;
+
+/**
+ * Format a test status line with count
+ */
+export function formatStatusLine(
+  status: keyof typeof statusSymbols,
+  count: number,
+  label?: string
+): string {
+  const symbol = statusSymbols[status];
+  const text = label || status;
+  const color = status === "passed" ? pc.green : status === "failed" ? pc.red : pc.yellow;
+  return color(`  ${symbol} ${count} ${text}`);
+}
+
+/**
+ * Format a summary line (e.g., "10 tests in 2.5s")
+ */
+export function formatSummaryLine(testCount: number, duration: number): string {
+  return pc.dim(`  ${testCount} tests in ${formatDuration(duration)}`);
+}

--- a/packages/results/src/streaming.ts
+++ b/packages/results/src/streaming.ts
@@ -12,6 +12,7 @@ import type { Test, TestStatus, Report } from "ctrf";
 import pc from "picocolors";
 import { applyDiffHighlighting } from "./diff-utils.js";
 import { SPINNER_FRAMES } from "./spinner.js";
+import { formatDuration } from "./log-formatting.js";
 import logUpdate from "log-update";
 
 /**
@@ -76,16 +77,6 @@ export const stdoutWriter: StreamWriter = {
     process.stdout.write(text + "\n");
   },
 };
-
-/**
- * Format duration in human-readable format
- */
-function formatDuration(ms: number): string {
-  if (ms < 1000) {
-    return `${Math.round(ms)}ms`;
-  }
-  return `${(ms / 1000).toFixed(2)}s`;
-}
 
 /**
  * Filter options for controlling which test statuses are shown in console output.

--- a/packages/results/src/summary.ts
+++ b/packages/results/src/summary.ts
@@ -6,6 +6,7 @@
 
 import type { Summary } from "ctrf";
 import pc from "picocolors";
+import { formatDuration, formatHint, formatSummaryLine } from "./log-formatting.js";
 
 /**
  * Options for filtering summary output based on test statuses
@@ -16,16 +17,6 @@ export interface SummaryOptions {
   skipped?: boolean;
   pending?: boolean;
   other?: boolean;
-}
-
-/**
- * Format duration in human-readable format
- */
-function formatDuration(ms: number): string {
-  if (ms < 1000) {
-    return `${Math.round(ms)}ms`;
-  }
-  return `${(ms / 1000).toFixed(2)}s`;
 }
 
 /**
@@ -69,9 +60,7 @@ export function printSummary(summary: Summary): void {
   }
 
   console.log("");
-  console.log(
-    pc.dim(`  ${summary.tests} tests in ${formatDuration(duration)}`),
-  );
+  console.log(formatSummaryLine(summary.tests, duration));
   console.log("");
 
   // Build legend based on enabled statuses
@@ -83,7 +72,7 @@ export function printSummary(summary: Summary): void {
   if (showOther) legendParts.push("◆ other");
 
   if (legendParts.length > 0) {
-    console.log(pc.dim(`  Legend: ${legendParts.join("  ")}`));
+    console.log(formatHint(`Legend: ${legendParts.join("  ")}`));
     console.log("");
   }
 }

--- a/packages/results/src/summary.ts
+++ b/packages/results/src/summary.ts
@@ -6,7 +6,7 @@
 
 import type { Summary } from "ctrf";
 import pc from "picocolors";
-import { formatDuration, formatHint, formatSummaryLine } from "./log-formatting.js";
+import { formatHint, formatSummaryLine } from "./log-formatting.js";
 
 /**
  * Options for filtering summary output based on test statuses


### PR DESCRIPTION
## Summary

Adds a helpful hint to the test runner suggesting the `--verbose` flag when tests complete, and introduces centralized log formatting utilities to eliminate code duplication.

## Motivation for the change, related issues

Users may not be aware of the `--verbose` flag to see detailed test output. This is particularly relevant given the recent changes to show only failed tests by default (#180). A contextual hint improves discoverability of this useful feature.

Additionally, the `formatDuration` function was duplicated across streaming.ts and summary.ts, violating the DRY principle.

## Implementation details

### Log Formatting Utilities

Created `packages/results/src/log-formatting.ts` with centralized formatting functions:
- `formatDuration()` - Converts milliseconds to human-readable format (e.g., "1.23s")
- `formatHint()` - Applies consistent dimmed styling for hints and legends
- `formatStatusLine()` - Formats status symbols with counts
- `formatSummaryLine()` - Formats test count and duration summary
- `statusSymbols` - Consistent colored symbols (✓, ✗, ○, etc.)

All utilities use picocolors for terminal color support and maintain consistent spacing/indentation.

### Verbose Mode Hint

After test execution completes, if `--verbose` is not enabled, the runner displays:
```
  Hint: Use --verbose to see the output of all tests
```

This hint:
- Only appears when verbose mode is disabled
- Uses the new `formatHint()` utility for consistent styling
- Appears after the test summary

### Refactoring

Updated streaming.ts and summary.ts to use the centralized `formatDuration()` function, removing duplicate implementations.

## Testing Instructions

1. Run the test suite without verbose mode:
   ```bash
   npm test
   ```
2. Confirm the hint "Use --verbose to see the output of all tests" appears after the summary
3. Run with verbose mode:
   ```bash
   npm test -- --verbose
   ```
4. Confirm the hint does NOT appear
5. Verify test summaries still display correctly with proper duration formatting