### PR TITLE
Replace wp, theme, plugin test types with smokeTests

### DIFF
--- a/packages/cli/src/cli/cli.ts
+++ b/packages/cli/src/cli/cli.ts
@@ -30,7 +30,7 @@ void yargs(hideBin(process.argv))
         .positional("action", {
           describe: "Action to perform",
           type: "string",
-          choices: ["validate", ...optionNames] as const,
+          choices: ["validate", "migrate", ...optionNames] as const,
           demandOption: true,
         })
         .option("config", {

--- a/packages/cli/src/cli/cli.ts
+++ b/packages/cli/src/cli/cli.ts
@@ -56,9 +56,9 @@ void yargs(hideBin(process.argv))
         })
         .option("test", {
           alias: "t",
-          describe: "Type of test to run (wp, plugin, theme, or phpunit)",
+          describe: "Type of test to run (smoke or phpunit)",
           type: "string",
-          choices: ["wp", "plugin", "theme", "phpunit"] as const,
+          choices: ["smoke", "phpunit"] as const,
         })
         .option("watch", {
           alias: "w",

--- a/packages/cli/src/commands/config/index.ts
+++ b/packages/cli/src/commands/config/index.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from 'fs/promises';
-import { optionNames, type OptionName, normalizeConfigPath } from '@wp-tester/config';
+import { optionNames, type OptionName, normalizeConfigPath, type WPTesterConfig } from '@wp-tester/config';
 import { updateConfigOption } from './option';
 import * as clack from '../../cli/theme';
 import { validateConfig, generateConfigSummary, printConfigSummary } from './validate';
@@ -46,7 +46,7 @@ async function runMigrate(configPath: string): Promise<void> {
   try {
     const resolvedConfigPath = normalizeConfigPath(configPath);
     const configContent = await readFile(resolvedConfigPath, 'utf-8');
-    const config = JSON.parse(configContent);
+    const config = JSON.parse(configContent) as WPTesterConfig;
 
     const result = migrateConfig(config);
 

--- a/packages/cli/src/commands/config/index.ts
+++ b/packages/cli/src/commands/config/index.ts
@@ -1,7 +1,9 @@
-import { optionNames, type OptionName } from '@wp-tester/config';
+import { readFile, writeFile } from 'fs/promises';
+import { optionNames, type OptionName, normalizeConfigPath } from '@wp-tester/config';
 import { updateConfigOption } from './option';
 import * as clack from '../../cli/theme';
 import { validateConfig, generateConfigSummary, printConfigSummary } from './validate';
+import { migrateConfig } from './migrate';
 import pc from 'picocolors';
 
 interface ConfigArgs {
@@ -13,15 +15,22 @@ export const configHandler = async (argv: ConfigArgs): Promise<void> => {
   const { action, config = './wp-tester.json' } = argv;
 
   if (action === "validate") {
-    const validatedConfig = await validateConfig(config);
-    if (!validatedConfig) {
+    const result = await validateConfig(config);
+    if (!result.config) {
       process.exit(1);
     }
     console.log(pc.green(pc.bold("✓ Configuration is valid")));
 
     // Display configuration summary
-    const summary = generateConfigSummary(validatedConfig);
+    const summary = generateConfigSummary(result.config);
     printConfigSummary(summary);
+
+    // Show migrate hint if there are deprecation warnings
+    if (result.hasDeprecationWarnings) {
+      clack.log.info(pc.dim(`Run ${pc.cyan('wp-tester config migrate')} to automatically update your configuration.`));
+    }
+  } else if (action === "migrate") {
+    await runMigrate(config);
   } else if (action && optionNames.includes(action as OptionName)) {
     await updateConfigOption(action as OptionName, config);
   } else {
@@ -29,5 +38,42 @@ export const configHandler = async (argv: ConfigArgs): Promise<void> => {
     process.exit(1);
   }
 };
+
+/**
+ * Run the config migration command
+ */
+async function runMigrate(configPath: string): Promise<void> {
+  try {
+    const resolvedConfigPath = normalizeConfigPath(configPath);
+    const configContent = await readFile(resolvedConfigPath, 'utf-8');
+    const config = JSON.parse(configContent);
+
+    const result = migrateConfig(config);
+
+    if (!result.migrated) {
+      console.log(pc.green(pc.bold("✓ No deprecated properties found. Configuration is up to date.")));
+      return;
+    }
+
+    // Show changes that will be made
+    clack.log.info(pc.bold('Migration changes:'));
+    for (const change of result.changes) {
+      clack.log.info(pc.cyan(`  • ${change}`));
+    }
+
+    // Write the updated config
+    const updatedContent = JSON.stringify(result.config, null, 2) + '\n';
+    await writeFile(resolvedConfigPath, updatedContent, 'utf-8');
+
+    console.log('');
+    console.log(pc.green(pc.bold("✓ Configuration migrated successfully.")));
+    clack.log.info(pc.dim(`Updated: ${resolvedConfigPath}`));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    clack.log.error("Migration error:");
+    clack.log.error(message);
+    process.exit(1);
+  }
+}
 
 export default configHandler;

--- a/packages/cli/src/commands/config/migrate.ts
+++ b/packages/cli/src/commands/config/migrate.ts
@@ -1,0 +1,81 @@
+import type { WPTesterConfig, Tests } from '@wp-tester/config';
+
+/**
+ * Result of a config migration
+ */
+export interface MigrationResult {
+  /** Whether any migrations were applied */
+  migrated: boolean;
+  /** The migrated config (or original if no changes) */
+  config: WPTesterConfig;
+  /** List of changes made */
+  changes: string[];
+}
+
+/**
+ * Migrate deprecated config properties to new format.
+ *
+ * Migrations:
+ * - tests.wp: true → tests.smokeTests: true
+ * - tests.plugin: "name" → projectType: "plugin" + tests.smokeTests: true
+ * - tests.theme: "name" → projectType: "theme" + tests.smokeTests: true
+ */
+export function migrateConfig(config: WPTesterConfig): MigrationResult {
+  const changes: string[] = [];
+
+  // Deep clone the config to avoid mutating the original
+  const newConfig: WPTesterConfig = JSON.parse(JSON.stringify(config));
+  const tests = newConfig.tests as Tests & { wp?: boolean; plugin?: string; theme?: string };
+
+  // Migrate tests.wp
+  if (tests.wp !== undefined) {
+    if (tests.wp === true) {
+      // Only set smokeTests if not already set
+      if (tests.smokeTests === undefined) {
+        tests.smokeTests = true;
+      }
+      changes.push('Migrated tests.wp to tests.smokeTests');
+    } else {
+      changes.push('Removed deprecated tests.wp (was false)');
+    }
+    delete tests.wp;
+  }
+
+  // Migrate tests.plugin
+  if (tests.plugin !== undefined) {
+    // Set projectType if not already set
+    if (newConfig.projectType === undefined) {
+      newConfig.projectType = 'plugin';
+      changes.push('Migrated tests.plugin to projectType: "plugin" and tests.smokeTests: true');
+    } else {
+      changes.push('Removed deprecated tests.plugin (projectType already set)');
+    }
+    // Enable smokeTests if not already set
+    if (tests.smokeTests === undefined) {
+      tests.smokeTests = true;
+    }
+    delete tests.plugin;
+  }
+
+  // Migrate tests.theme
+  if (tests.theme !== undefined) {
+    // Set projectType if not already set (and not set by plugin migration)
+    if (newConfig.projectType === undefined) {
+      newConfig.projectType = 'theme';
+      changes.push('Migrated tests.theme to projectType: "theme" and tests.smokeTests: true');
+    } else {
+      changes.push('Removed deprecated tests.theme (projectType already set)');
+    }
+    // Enable smokeTests if not already set
+    if (tests.smokeTests === undefined) {
+      tests.smokeTests = true;
+    }
+    delete tests.theme;
+  }
+
+  return {
+    migrated: changes.length > 0,
+    config: newConfig,
+    changes,
+  };
+}

--- a/packages/cli/src/commands/config/migrate.ts
+++ b/packages/cli/src/commands/config/migrate.ts
@@ -24,7 +24,7 @@ export function migrateConfig(config: WPTesterConfig): MigrationResult {
   const changes: string[] = [];
 
   // Deep clone the config to avoid mutating the original
-  const newConfig: WPTesterConfig = JSON.parse(JSON.stringify(config));
+  const newConfig = JSON.parse(JSON.stringify(config)) as WPTesterConfig;
   const tests = newConfig.tests as Tests & { wp?: boolean; plugin?: string; theme?: string };
 
   // Migrate tests.wp

--- a/packages/cli/src/commands/config/validate.ts
+++ b/packages/cli/src/commands/config/validate.ts
@@ -65,20 +65,34 @@ export interface ConfigSummary {
 }
 
 /**
- * Get a list of enabled test suites from the tests configuration
+ * Get a list of enabled test suites from the configuration
  */
-export function getEnabledTestSuites(tests: Tests): TestSuiteSummary[] {
+export function getEnabledTestSuites(tests: Tests, projectType?: string): TestSuiteSummary[] {
   const suites: TestSuiteSummary[] = [];
 
-  if (tests.wp) {
+  // Handle smokeTests (new format)
+  if (tests.smokeTests !== undefined && tests.smokeTests !== false) {
+    // WordPress tests always run with smokeTests
+    suites.push({ name: 'wp', label: 'Smoke Tests (WordPress)' });
+
+    // Plugin/theme tests based on projectType
+    if (projectType === 'plugin') {
+      suites.push({ name: 'plugin', label: 'Smoke Tests (Plugin)' });
+    } else if (projectType === 'theme') {
+      suites.push({ name: 'theme', label: 'Smoke Tests (Theme)' });
+    }
+  }
+
+  // Handle legacy properties (deprecated but still supported)
+  if (tests.wp && tests.smokeTests === undefined) {
     suites.push({ name: 'wp', label: 'WordPress' });
   }
 
-  if (tests.plugin) {
+  if (tests.plugin && tests.smokeTests === undefined) {
     suites.push({ name: 'plugin', label: `Plugin (${tests.plugin})` });
   }
 
-  if (tests.theme) {
+  if (tests.theme && tests.smokeTests === undefined) {
     suites.push({ name: 'theme', label: `Theme (${tests.theme})` });
   }
 
@@ -96,7 +110,7 @@ export function getEnabledTestSuites(tests: Tests): TestSuiteSummary[] {
 export function generateConfigSummary(config: WPTesterConfig): ConfigSummary {
   const activeEnvironments = config.environments.filter(env => !env.skip).length;
   const skippedEnvironments = config.environments.filter(env => env.skip).length;
-  const testSuites = getEnabledTestSuites(config.tests);
+  const testSuites = getEnabledTestSuites(config.tests, config.projectType);
   const matrixCombinations = activeEnvironments * testSuites.length;
 
   return {
@@ -238,10 +252,20 @@ export function formatValidationError(error: ErrorObject): ValidationErrorDispla
 }
 
 /**
+ * Result of config validation
+ */
+export interface ValidationResult {
+  /** The validated config if valid, null otherwise */
+  config: WPTesterConfig | null;
+  /** Whether there are deprecation warnings */
+  hasDeprecationWarnings: boolean;
+}
+
+/**
  * Validates config and prints errors if invalid.
  * Returns the validated config if valid, null otherwise.
  */
-export async function validateConfig(configPath: string): Promise<WPTesterConfig | null> {
+export async function validateConfig(configPath: string): Promise<ValidationResult> {
   try {
     // Resolve config path relative to cwd and normalize (handles directory paths)
     const resolvedConfigPath = normalizeConfigPath(configPath);
@@ -285,7 +309,7 @@ export async function validateConfig(configPath: string): Promise<WPTesterConfig
         }
       }
 
-      return null;
+      return { config: null, hasDeprecationWarnings: false };
     }
 
     // Check for skipped environments and display info
@@ -301,6 +325,7 @@ export async function validateConfig(configPath: string): Promise<WPTesterConfig
     }
 
     // Check for deprecated properties and warn
+    let hasDeprecationWarnings = false;
     if (typedConfig.tests) {
       const deprecationWarnings = checkDeprecatedTestProperties(typedConfig.tests);
       for (const warning of deprecationWarnings) {
@@ -308,15 +333,16 @@ export async function validateConfig(configPath: string): Promise<WPTesterConfig
         clack.log.info(pc.dim(`  ${warning.replacement}`));
       }
       if (deprecationWarnings.length > 0) {
+        hasDeprecationWarnings = true;
         clack.log.info('');
       }
     }
 
-    return typedConfig;
+    return { config: typedConfig, hasDeprecationWarnings };
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
     clack.log.error("Validation error:");
     clack.log.error(message);
-    return null;
+    return { config: null, hasDeprecationWarnings: false };
   }
 }

--- a/packages/cli/src/commands/config/validate.ts
+++ b/packages/cli/src/commands/config/validate.ts
@@ -5,6 +5,48 @@ import { getSchemaPath, normalizeConfigPath, type WPTesterConfig, type Tests } f
 import * as clack from "../../cli/theme";
 
 /**
+ * Deprecation warning for a configuration property
+ */
+interface DeprecationWarning {
+  property: string;
+  message: string;
+  replacement: string;
+}
+
+/**
+ * Check for deprecated properties in the tests configuration
+ */
+export function checkDeprecatedTestProperties(tests: Tests): DeprecationWarning[] {
+  const warnings: DeprecationWarning[] = [];
+
+  if (tests.wp !== undefined) {
+    warnings.push({
+      property: 'tests.wp',
+      message: 'tests.wp is deprecated',
+      replacement: 'Use "smokeTests": true instead',
+    });
+  }
+
+  if (tests.plugin !== undefined) {
+    warnings.push({
+      property: 'tests.plugin',
+      message: 'tests.plugin is deprecated',
+      replacement: 'Set "projectType": "plugin" and use "smokeTests": true instead',
+    });
+  }
+
+  if (tests.theme !== undefined) {
+    warnings.push({
+      property: 'tests.theme',
+      message: 'tests.theme is deprecated',
+      replacement: 'Set "projectType": "theme" and use "smokeTests": true instead',
+    });
+  }
+
+  return warnings;
+}
+
+/**
  * Summary of enabled test suites
  */
 export interface TestSuiteSummary {
@@ -255,6 +297,18 @@ export async function validateConfig(configPath: string): Promise<WPTesterConfig
           const envName = env.name || 'Unnamed environment';
           clack.log.warn(pc.yellow(` ${envName} (Skipped)`));
         }
+      }
+    }
+
+    // Check for deprecated properties and warn
+    if (typedConfig.tests) {
+      const deprecationWarnings = checkDeprecatedTestProperties(typedConfig.tests);
+      for (const warning of deprecationWarnings) {
+        clack.log.warn(pc.yellow(`Deprecated: ${warning.message}`));
+        clack.log.info(pc.dim(`  ${warning.replacement}`));
+      }
+      if (deprecationWarnings.length > 0) {
+        clack.log.info('');
       }
     }
 

--- a/packages/cli/src/commands/test/runner.ts
+++ b/packages/cli/src/commands/test/runner.ts
@@ -13,7 +13,7 @@ import { getConfigPath } from "@wp-tester/config";
  * Options for the test runner
  */
 export interface RunTestsOptions {
-  /** Type of test to run (phpunit, wp, plugin, theme) */
+  /** Type of test to run (smoke or phpunit) */
   testType?: TestType;
   /** Additional arguments to pass to test runners */
   extraArgs?: string[];
@@ -120,17 +120,11 @@ async function checkConfigExists(configPath: string): Promise<boolean> {
 }
 
 /**
- * Determines if the given test type is a smoke test type.
- * Returns the test type if it's a smoke test, undefined if no filter needed, or false if it should be skipped.
+ * Determines if smoke tests should run based on test type.
+ * Returns true if smoke tests should run, false otherwise.
  */
-function getSmokeTestFilter(testType?: TestType): TestType | undefined | false {
-  const smokeTestTypes: TestType[] = ["wp", "plugin", "theme"];
-
-  if (!testType) {
-    return undefined; // Run all smoke tests
-  }
-
-  return smokeTestTypes.includes(testType) ? testType : false;
+function shouldRunSmokeTests(testType?: TestType): boolean {
+  return !testType || testType === "smoke";
 }
 
 export interface TestResult {
@@ -161,8 +155,8 @@ export const executeTests = async (
   resolvedConfig = applyFilterOverride(resolvedConfig, verbose);
 
   // Determine which tests to run based on testType parameter
-  const shouldRunPhpUnit = !testType || testType === "phpunit";
-  const smokeTestFilter = getSmokeTestFilter(testType);
+  const runPhpUnit = !testType || testType === "phpunit";
+  const runSmoke = shouldRunSmokeTests(testType);
 
   // Get streaming configuration
   // Default to true if not explicitly disabled (was causing regression where no output showed)
@@ -182,14 +176,14 @@ export const executeTests = async (
   unifiedReporter.startUnifiedRun();
 
   try {
-    // Run smoke tests (wp, plugin, theme)
-    if (smokeTestFilter !== false) {
+    // Run smoke tests
+    if (runSmoke) {
       unifiedReporter.setStatus("Running smoke tests");
-      await runSmokeTests(resolvedConfig, smokeTestFilter, extraArgs, unifiedReporter);
+      await runSmokeTests(resolvedConfig, extraArgs, unifiedReporter);
     }
 
     // Run PHPUnit tests
-    if (shouldRunPhpUnit) {
+    if (runPhpUnit) {
       unifiedReporter.setStatus("Running PHPUnit tests");
       await runPhpunitTests(resolvedConfig, extraArgs, unifiedReporter);
     }

--- a/packages/cli/tests/integration/json-reporter.spec.ts
+++ b/packages/cli/tests/integration/json-reporter.spec.ts
@@ -25,7 +25,7 @@ describe('JSON Reporter Integration', { timeout: 120000 }, () => {
   it('should write JSON report file with default outputFile path using empty object', async () => {
     const config: WPTesterConfig = {
       environments: [{ blueprint: { landingPage: '/' } }],
-      tests: { wp: true },
+      tests: { smokeTests: true },
       reporters: { json: {} },
     };
     await writeFile(configFile, JSON.stringify(config, null, 2));
@@ -51,7 +51,7 @@ describe('JSON Reporter Integration', { timeout: 120000 }, () => {
   it('should write JSON report file with default outputFile path using true shorthand', async () => {
     const config: WPTesterConfig = {
       environments: [{ blueprint: { landingPage: '/' } }],
-      tests: { wp: true },
+      tests: { smokeTests: true },
       reporters: { json: true },
     };
     await writeFile(configFile, JSON.stringify(config, null, 2));
@@ -78,7 +78,7 @@ describe('JSON Reporter Integration', { timeout: 120000 }, () => {
     const customOutputFile = join(testDir, 'custom-output.json');
     const config: WPTesterConfig = {
       environments: [{ blueprint: { landingPage: '/' } }],
-      tests: { wp: true },
+      tests: { smokeTests: true },
       reporters: { json: { outputFile: 'custom-output.json' } },
     };
     await writeFile(configFile, JSON.stringify(config, null, 2));
@@ -99,7 +99,7 @@ describe('JSON Reporter Integration', { timeout: 120000 }, () => {
   it('should not write JSON report file when json reporter is not configured', async () => {
     const config: WPTesterConfig = {
       environments: [{ blueprint: { landingPage: '/' } }],
-      tests: { wp: true },
+      tests: { smokeTests: true },
     };
     await writeFile(configFile, JSON.stringify(config, null, 2));
 
@@ -112,7 +112,7 @@ describe('JSON Reporter Integration', { timeout: 120000 }, () => {
   it('should always include all tests in JSON output regardless of filter settings', async () => {
     const config: WPTesterConfig = {
       environments: [{ blueprint: { landingPage: '/' } }],
-      tests: { wp: true },
+      tests: { smokeTests: true },
       reporters: { json: {} },
     };
     await writeFile(configFile, JSON.stringify(config, null, 2));

--- a/packages/cli/tests/migrate.spec.ts
+++ b/packages/cli/tests/migrate.spec.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import { migrateConfig, type MigrationResult } from '../src/commands/config/migrate';
+import type { WPTesterConfig } from '@wp-tester/config';
+
+describe('migrateConfig', () => {
+  describe('tests.wp migration', () => {
+    it('should migrate tests.wp: true to smokeTests: true', () => {
+      const config: WPTesterConfig = {
+        environments: [{ php: ['8.2'], wp: ['6.7'] }],
+        tests: { wp: true },
+      };
+
+      const result = migrateConfig(config);
+
+      expect(result.migrated).toBe(true);
+      expect(result.config.tests.smokeTests).toBe(true);
+      expect(result.config.tests.wp).toBeUndefined();
+      expect(result.changes).toContain('Migrated tests.wp to tests.smokeTests');
+    });
+
+    it('should not migrate when tests.wp is false', () => {
+      const config: WPTesterConfig = {
+        environments: [{ php: ['8.2'], wp: ['6.7'] }],
+        tests: { wp: false },
+      };
+
+      const result = migrateConfig(config);
+
+      expect(result.migrated).toBe(true);
+      expect(result.config.tests.wp).toBeUndefined();
+      expect(result.changes).toContain('Removed deprecated tests.wp (was false)');
+    });
+
+    it('should preserve existing smokeTests when migrating tests.wp', () => {
+      const config: WPTesterConfig = {
+        environments: [{ php: ['8.2'], wp: ['6.7'] }],
+        tests: { wp: true, smokeTests: { include: ['wpBoot'] } },
+      };
+
+      const result = migrateConfig(config);
+
+      expect(result.migrated).toBe(true);
+      expect(result.config.tests.smokeTests).toEqual({ include: ['wpBoot'] });
+      expect(result.config.tests.wp).toBeUndefined();
+    });
+  });
+
+  describe('tests.plugin migration', () => {
+    it('should migrate tests.plugin to projectType: plugin and smokeTests: true', () => {
+      const config: WPTesterConfig = {
+        environments: [{ php: ['8.2'], wp: ['6.7'] }],
+        tests: { plugin: 'my-plugin' },
+      };
+
+      const result = migrateConfig(config);
+
+      expect(result.migrated).toBe(true);
+      expect(result.config.projectType).toBe('plugin');
+      expect(result.config.tests.smokeTests).toBe(true);
+      expect(result.config.tests.plugin).toBeUndefined();
+      expect(result.changes).toContain('Migrated tests.plugin to projectType: "plugin" and tests.smokeTests: true');
+    });
+
+    it('should not override existing projectType when migrating tests.plugin', () => {
+      const config: WPTesterConfig = {
+        environments: [{ php: ['8.2'], wp: ['6.7'] }],
+        projectType: 'theme',
+        tests: { plugin: 'my-plugin' },
+      };
+
+      const result = migrateConfig(config);
+
+      expect(result.migrated).toBe(true);
+      expect(result.config.projectType).toBe('theme'); // Preserved
+      expect(result.config.tests.smokeTests).toBe(true);
+      expect(result.config.tests.plugin).toBeUndefined();
+      expect(result.changes).toContain('Removed deprecated tests.plugin (projectType already set)');
+    });
+  });
+
+  describe('tests.theme migration', () => {
+    it('should migrate tests.theme to projectType: theme and smokeTests: true', () => {
+      const config: WPTesterConfig = {
+        environments: [{ php: ['8.2'], wp: ['6.7'] }],
+        tests: { theme: 'my-theme' },
+      };
+
+      const result = migrateConfig(config);
+
+      expect(result.migrated).toBe(true);
+      expect(result.config.projectType).toBe('theme');
+      expect(result.config.tests.smokeTests).toBe(true);
+      expect(result.config.tests.theme).toBeUndefined();
+      expect(result.changes).toContain('Migrated tests.theme to projectType: "theme" and tests.smokeTests: true');
+    });
+
+    it('should not override existing projectType when migrating tests.theme', () => {
+      const config: WPTesterConfig = {
+        environments: [{ php: ['8.2'], wp: ['6.7'] }],
+        projectType: 'plugin',
+        tests: { theme: 'my-theme' },
+      };
+
+      const result = migrateConfig(config);
+
+      expect(result.migrated).toBe(true);
+      expect(result.config.projectType).toBe('plugin'); // Preserved
+      expect(result.config.tests.smokeTests).toBe(true);
+      expect(result.config.tests.theme).toBeUndefined();
+      expect(result.changes).toContain('Removed deprecated tests.theme (projectType already set)');
+    });
+  });
+
+  describe('combined migrations', () => {
+    it('should migrate all deprecated properties at once', () => {
+      const config: WPTesterConfig = {
+        environments: [{ php: ['8.2'], wp: ['6.7'] }],
+        tests: { wp: true, plugin: 'my-plugin', theme: 'my-theme' },
+      };
+
+      const result = migrateConfig(config);
+
+      expect(result.migrated).toBe(true);
+      expect(result.config.tests.smokeTests).toBe(true);
+      expect(result.config.tests.wp).toBeUndefined();
+      expect(result.config.tests.plugin).toBeUndefined();
+      expect(result.config.tests.theme).toBeUndefined();
+      // plugin takes precedence over theme for projectType
+      expect(result.config.projectType).toBe('plugin');
+      expect(result.changes.length).toBe(3);
+    });
+
+    it('should return migrated: false when no deprecated properties exist', () => {
+      const config: WPTesterConfig = {
+        environments: [{ php: ['8.2'], wp: ['6.7'] }],
+        tests: { smokeTests: true },
+      };
+
+      const result = migrateConfig(config);
+
+      expect(result.migrated).toBe(false);
+      expect(result.changes).toHaveLength(0);
+    });
+
+    it('should preserve non-deprecated properties', () => {
+      const config: WPTesterConfig = {
+        environments: [{ php: ['8.2'], wp: ['6.7'] }],
+        tests: {
+          wp: true,
+          phpunit: { phpunitPath: 'vendor/bin/phpunit', configPath: 'phpunit.xml' },
+        },
+      };
+
+      const result = migrateConfig(config);
+
+      expect(result.migrated).toBe(true);
+      expect(result.config.tests.phpunit).toEqual({
+        phpunitPath: 'vendor/bin/phpunit',
+        configPath: 'phpunit.xml',
+      });
+    });
+
+    it('should preserve $schema property', () => {
+      const config: WPTesterConfig = {
+        $schema: './node_modules/@wp-tester/config/schema.json',
+        environments: [{ php: ['8.2'], wp: ['6.7'] }],
+        tests: { wp: true },
+      };
+
+      const result = migrateConfig(config);
+
+      expect(result.config.$schema).toBe('./node_modules/@wp-tester/config/schema.json');
+    });
+  });
+});

--- a/packages/cli/tests/migrate.spec.ts
+++ b/packages/cli/tests/migrate.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { migrateConfig, type MigrationResult } from '../src/commands/config/migrate';
+import { migrateConfig } from '../src/commands/config/migrate';
 import type { WPTesterConfig } from '@wp-tester/config';
 
 describe('migrateConfig', () => {

--- a/packages/cli/tests/validate.spec.ts
+++ b/packages/cli/tests/validate.spec.ts
@@ -134,45 +134,83 @@ describe('getEnabledTestSuites', () => {
     expect(result).toEqual([]);
   });
 
-  it('should include WordPress tests when wp is true', () => {
-    const tests: Tests = { wp: true };
-    const result = getEnabledTestSuites(tests);
-    expect(result.map((s) => s.name)).toContain("wp");
+  describe('legacy properties (deprecated)', () => {
+    it('should include WordPress tests when wp is true', () => {
+      const tests: Tests = { wp: true };
+      const result = getEnabledTestSuites(tests);
+      expect(result.map((s) => s.name)).toContain("wp");
+    });
+
+    it('should include plugin tests with plugin name', () => {
+      const tests: Tests = { plugin: 'my-plugin' };
+      const result = getEnabledTestSuites(tests);
+      expect(result.map((s) => s.name)).toContain("plugin");
+    });
+
+    it('should include theme tests with theme name', () => {
+      const tests: Tests = { theme: 'my-theme' };
+      const result = getEnabledTestSuites(tests);
+      expect(result.map((s) => s.name)).toContain("theme");
+    });
+
+    it('should include all enabled legacy test suites', () => {
+      const tests: Tests = {
+        wp: true,
+        plugin: 'my-plugin',
+        phpunit: { phpunitPath: 'vendor/bin/phpunit', configPath: 'phpunit.xml', testMode: 'integration' }
+      };
+      const result = getEnabledTestSuites(tests);
+      expect(result).toHaveLength(3);
+      expect(result.map(s => s.name)).toEqual(['wp', 'plugin', 'phpunit']);
+    });
   });
 
-  it('should include plugin tests with plugin name', () => {
-    const tests: Tests = { plugin: 'my-plugin' };
-    const result = getEnabledTestSuites(tests);
-    expect(result.map((s) => s.name)).toContain("plugin");
+  describe('smokeTests property (new format)', () => {
+    it('should include wp tests when smokeTests is true', () => {
+      const tests: Tests = { smokeTests: true };
+      const result = getEnabledTestSuites(tests);
+      expect(result.map((s) => s.name)).toContain("wp");
+    });
+
+    it('should include wp and plugin tests when smokeTests is true and projectType is plugin', () => {
+      const tests: Tests = { smokeTests: true };
+      const result = getEnabledTestSuites(tests, 'plugin');
+      expect(result.map((s) => s.name)).toContain("wp");
+      expect(result.map((s) => s.name)).toContain("plugin");
+    });
+
+    it('should include wp and theme tests when smokeTests is true and projectType is theme', () => {
+      const tests: Tests = { smokeTests: true };
+      const result = getEnabledTestSuites(tests, 'theme');
+      expect(result.map((s) => s.name)).toContain("wp");
+      expect(result.map((s) => s.name)).toContain("theme");
+    });
+
+    it('should not include plugin/theme tests when smokeTests is true and projectType is wordpress', () => {
+      const tests: Tests = { smokeTests: true };
+      const result = getEnabledTestSuites(tests, 'wordpress');
+      expect(result.map((s) => s.name)).toEqual(['wp']);
+    });
+
+    it('should return empty array when smokeTests is false', () => {
+      const tests: Tests = { smokeTests: false };
+      const result = getEnabledTestSuites(tests);
+      expect(result).toEqual([]);
+    });
   });
 
-  it('should include theme tests with theme name', () => {
-    const tests: Tests = { theme: 'my-theme' };
-    const result = getEnabledTestSuites(tests);
-    expect(result.map((s) => s.name)).toContain("theme");
-  });
+  describe('PHPUnit tests', () => {
+    it('should include PHPUnit tests with unit mode by default', () => {
+      const tests: Tests = { phpunit: { phpunitPath: 'vendor/bin/phpunit', configPath: 'phpunit.xml' } };
+      const result = getEnabledTestSuites(tests);
+      expect(result.map((s) => s.name)).toContain("phpunit");
+    });
 
-  it('should include PHPUnit tests with unit mode by default', () => {
-    const tests: Tests = { phpunit: { phpunitPath: 'vendor/bin/phpunit', configPath: 'phpunit.xml' } };
-    const result = getEnabledTestSuites(tests);
-    expect(result.map((s) => s.name)).toContain("phpunit");
-  });
-
-  it('should include PHPUnit tests with integration mode', () => {
-    const tests: Tests = { phpunit: { phpunitPath: 'vendor/bin/phpunit', configPath: 'phpunit.xml', testMode: 'integration' } };
-    const result = getEnabledTestSuites(tests);
-    expect(result.map((s) => s.name)).toContain("phpunit");
-  });
-
-  it('should include all enabled test suites', () => {
-    const tests: Tests = {
-      wp: true,
-      plugin: 'my-plugin',
-      phpunit: { phpunitPath: 'vendor/bin/phpunit', configPath: 'phpunit.xml', testMode: 'integration' }
-    };
-    const result = getEnabledTestSuites(tests);
-    expect(result).toHaveLength(3);
-    expect(result.map(s => s.name)).toEqual(['wp', 'plugin', 'phpunit']);
+    it('should include PHPUnit tests with integration mode', () => {
+      const tests: Tests = { phpunit: { phpunitPath: 'vendor/bin/phpunit', configPath: 'phpunit.xml', testMode: 'integration' } };
+      const result = getEnabledTestSuites(tests);
+      expect(result.map((s) => s.name)).toContain("phpunit");
+    });
   });
 });
 

--- a/packages/cli/tests/validate.spec.ts
+++ b/packages/cli/tests/validate.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { type ErrorObject } from 'ajv';
-import { formatValidationError, getEnabledTestSuites, generateConfigSummary } from '../src/commands/config/validate';
+import { formatValidationError, getEnabledTestSuites, generateConfigSummary, checkDeprecatedTestProperties } from '../src/commands/config/validate';
 import type { Tests, WPTesterConfig } from '@wp-tester/config';
 import { Blueprint } from "@wp-playground/blueprints";
 
@@ -244,5 +244,60 @@ describe('generateConfigSummary', () => {
     };
     const result = generateConfigSummary(config);
     expect(result.matrixCombinations).toBe(0);
+  });
+});
+
+describe('checkDeprecatedTestProperties', () => {
+  it('should return no warnings when no deprecated properties are used', () => {
+    const tests: Tests = { smokeTests: true };
+    const warnings = checkDeprecatedTestProperties(tests);
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('should warn when tests.wp is used', () => {
+    const tests: Tests = { wp: true };
+    const warnings = checkDeprecatedTestProperties(tests);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].property).toBe('tests.wp');
+    expect(warnings[0].message).toContain('deprecated');
+    expect(warnings[0].replacement).toContain('smokeTests');
+  });
+
+  it('should warn when tests.plugin is used', () => {
+    const tests: Tests = { plugin: 'my-plugin' };
+    const warnings = checkDeprecatedTestProperties(tests);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].property).toBe('tests.plugin');
+    expect(warnings[0].replacement).toContain('projectType');
+  });
+
+  it('should warn when tests.theme is used', () => {
+    const tests: Tests = { theme: 'my-theme' };
+    const warnings = checkDeprecatedTestProperties(tests);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].property).toBe('tests.theme');
+    expect(warnings[0].replacement).toContain('projectType');
+  });
+
+  it('should warn for all deprecated properties when multiple are used', () => {
+    const tests: Tests = { wp: true, plugin: 'my-plugin', theme: 'my-theme' };
+    const warnings = checkDeprecatedTestProperties(tests);
+    expect(warnings).toHaveLength(3);
+  });
+
+  it('should not warn when wp is false', () => {
+    const tests: Tests = { wp: false };
+    const warnings = checkDeprecatedTestProperties(tests);
+    // wp: false still triggers the warning since the property is present
+    expect(warnings).toHaveLength(1);
+  });
+
+  it('should not warn for non-deprecated properties', () => {
+    const tests: Tests = {
+      smokeTests: true,
+      phpunit: { phpunitPath: 'vendor/bin/phpunit', configPath: 'phpunit.xml' }
+    };
+    const warnings = checkDeprecatedTestProperties(tests);
+    expect(warnings).toHaveLength(0);
   });
 });

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -8,7 +8,7 @@ import { getProjectRootMount } from "./auto-mount";
 import { detectProjectType } from "./options/project-type-detect";
 import { getProjectDir, resolveAbsolute, normalizeConfigPath } from "./path-utils";
 import { expandEnvironments } from "./environment-resolver";
-import { resolveTests } from "./test-resolver";
+import { resolveTests, deriveProjectSlug } from "./test-resolver";
 
 export type { WPTesterConfig } from "./wp-tester-config";
 
@@ -233,11 +233,15 @@ export async function resolveConfig(
     projectPath
   );
 
+  // Derive project slug: use explicit config value if set, otherwise derive from VFS path
+  const projectSlug = resolvedConfig.projectSlug ?? deriveProjectSlug(projectVFSPath, projectType);
+
   // Return fully resolved config with all required fields
   return {
     ...resolvedConfig,
     projectPath,
     projectType,
+    projectSlug,
     reporters,
     environments: resolvedEnvironments,
     tests: resolvedTests,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -55,6 +55,9 @@ export {
 export {
   resolvePhpunitArgs,
   resolveTests,
+  extractPluginSlug,
+  extractThemeSlug,
+  deriveProjectSlug,
 } from "./test-resolver";
 
 export {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -4,6 +4,7 @@ export type {
   EnvironmentVariables,
   Environment,
   Tests,
+  SmokeTests,
   PHPUnitConfig,
   TestType,
   Reporters,
@@ -55,6 +56,12 @@ export {
   resolvePhpunitArgs,
   resolveTests,
 } from "./test-resolver";
+
+export {
+  validateSmokeTests,
+  KNOWN_SMOKE_TESTS,
+  type SmokeTestsValidationResult,
+} from "./smoke-tests-validation";
 
 export {
   expandEnvironments,

--- a/packages/config/src/options/smoke-tests.ts
+++ b/packages/config/src/options/smoke-tests.ts
@@ -1,108 +1,31 @@
 import type { WPTesterConfig, Tests } from '../types';
-import * as clack from '@clack/prompts';
-import { getProjectDir } from '../path-utils';
-
-export function validateSlug(value: string): string | undefined {
-  if (!value || value.trim().length === 0) {
-    return 'Slug cannot be empty';
-  }
-  if (/\s/.test(value)) {
-    return 'Slug must be a single word (no spaces)';
-  }
-  return undefined;
-}
+import * as clack from "@clack/prompts";
 
 export async function smokeTestsOption(
-  config: WPTesterConfig
+  config: WPTesterConfig,
 ): Promise<WPTesterConfig> {
-  const tests: Tests = {};
+  const tests: Tests = { ...config.tests };
 
-  // Get default slug from project directory name
-  const projectHostPath = getProjectDir(config);
-  const defaultSlug = projectHostPath.split('/').pop() || '';
-
-  // Ask about WordPress smoke tests
-  const runWpTests = await clack.select({
-    message: "Run WordPress smoke tests?",
+  // Ask about smoke tests
+  const runSmokeTests = await clack.select({
+    message: "Run smoke tests?",
     options: [
-      { value: true, label: "Yes", hint: "Verifies WordPress doesn't crash with your code" },
+      {
+        value: true,
+        label: "Yes",
+        hint: "Verifies your project doesn't break standard WordPress functionality.",
+      },
       { value: false, label: "No" },
     ],
     initialValue: true,
   });
 
-  if (clack.isCancel(runWpTests)) {
+  if (clack.isCancel(runSmokeTests)) {
     clack.cancel("Setup cancelled.");
     process.exit(0);
   }
 
-  if (runWpTests) {
-    tests.wp = true;
-  }
-
-  // Ask about plugin tests if project type is plugin
-  if (config.projectType === 'plugin') {
-    const runPluginTests = await clack.select({
-      message: "Run plugin smoke tests?",
-      options: [
-        { value: true, label: "Yes", hint: "Verifies your plugin doesn't crash on activation" },
-        { value: false, label: "No" },
-      ],
-      initialValue: true,
-    });
-
-    if (clack.isCancel(runPluginTests)) {
-      clack.cancel("Setup cancelled.");
-      process.exit(0);
-    }
-
-    if (runPluginTests) {
-      const pluginSlug = await clack.text({
-        message: "Enter the plugin slug:",
-        initialValue: defaultSlug,
-        validate: validateSlug,
-      });
-
-      if (clack.isCancel(pluginSlug)) {
-        clack.cancel("Setup cancelled.");
-        process.exit(0);
-      }
-
-      tests.plugin = pluginSlug;
-    }
-  }
-
-  // Ask about theme tests if project type is theme
-  if (config.projectType === 'theme') {
-    const runThemeTests = await clack.select({
-      message: "Run theme smoke tests?",
-      options: [
-        { value: true, label: "Yes", hint: "Verifies your theme doesn't crash on activation" },
-        { value: false, label: "No" },
-      ],
-      initialValue: true,
-    });
-
-    if (clack.isCancel(runThemeTests)) {
-      clack.cancel("Setup cancelled.");
-      process.exit(0);
-    }
-
-    if (runThemeTests) {
-      const themeSlug = await clack.text({
-        message: "Enter the theme slug:",
-        initialValue: defaultSlug,
-        validate: validateSlug,
-      });
-
-      if (clack.isCancel(themeSlug)) {
-        clack.cancel("Setup cancelled.");
-        process.exit(0);
-      }
-
-      tests.theme = themeSlug;
-    }
-  }
+  tests.smokeTests = runSmokeTests;
 
   return {
     ...config,

--- a/packages/config/src/resolved-types.ts
+++ b/packages/config/src/resolved-types.ts
@@ -42,7 +42,7 @@ export interface ResolvedPHPUnitConfig {
 /**
  * Resolved test configuration with resolved PHPUnit config.
  */
-export interface ResolvedTests extends Omit<Tests, 'phpunit' | 'watch'> {
+export interface ResolvedTests extends Omit<Tests, 'phpunit' | 'watch' | 'plugin' | 'theme' | 'wp'> {
   phpunit?: ResolvedPHPUnitConfig;
   /** Allow the test suite to pass when no tests are executed */
   passWithNoTests?: boolean;

--- a/packages/config/src/resolved-types.ts
+++ b/packages/config/src/resolved-types.ts
@@ -42,7 +42,7 @@ export interface ResolvedPHPUnitConfig {
 /**
  * Resolved test configuration with resolved PHPUnit config.
  */
-export interface ResolvedTests extends Omit<Tests, 'phpunit'> {
+export interface ResolvedTests extends Omit<Tests, 'phpunit' | 'watch'> {
   phpunit?: ResolvedPHPUnitConfig;
   /** Allow the test suite to pass when no tests are executed */
   passWithNoTests?: boolean;

--- a/packages/config/src/schema.json
+++ b/packages/config/src/schema.json
@@ -43,7 +43,7 @@
     },
     "ArrayBuffer": {
       "properties": {
-        "__@toStringTag@570": {
+        "__@toStringTag@577": {
           "type": "string"
         },
         "byteLength": {
@@ -51,7 +51,7 @@
         }
       },
       "required": [
-        "__@toStringTag@570",
+        "__@toStringTag@577",
         "byteLength"
       ],
       "type": "object"
@@ -397,7 +397,7 @@
                                   "BYTES_PER_ELEMENT": {
                                     "type": "number"
                                   },
-                                  "__@toStringTag@570": {
+                                  "__@toStringTag@577": {
                                     "const": "Uint8Array",
                                     "type": "string"
                                   },
@@ -416,7 +416,7 @@
                                 },
                                 "required": [
                                   "BYTES_PER_ELEMENT",
-                                  "__@toStringTag@570",
+                                  "__@toStringTag@577",
                                   "buffer",
                                   "byteLength",
                                   "byteOffset",
@@ -1393,7 +1393,7 @@
                     "BYTES_PER_ELEMENT": {
                       "type": "number"
                     },
-                    "__@toStringTag@570": {
+                    "__@toStringTag@577": {
                       "const": "Uint8Array",
                       "type": "string"
                     },
@@ -1412,7 +1412,7 @@
                   },
                   "required": [
                     "BYTES_PER_ELEMENT",
-                    "__@toStringTag@570",
+                    "__@toStringTag@577",
                     "buffer",
                     "byteLength",
                     "byteOffset",
@@ -1654,7 +1654,7 @@
                         "BYTES_PER_ELEMENT": {
                           "type": "number"
                         },
-                        "__@toStringTag@570": {
+                        "__@toStringTag@577": {
                           "const": "Uint8Array",
                           "type": "string"
                         },
@@ -1673,7 +1673,7 @@
                       },
                       "required": [
                         "BYTES_PER_ELEMENT",
-                        "__@toStringTag@570",
+                        "__@toStringTag@577",
                         "buffer",
                         "byteLength",
                         "byteOffset",
@@ -1862,7 +1862,7 @@
                         "BYTES_PER_ELEMENT": {
                           "type": "number"
                         },
-                        "__@toStringTag@570": {
+                        "__@toStringTag@577": {
                           "const": "Uint8Array",
                           "type": "string"
                         },
@@ -1881,7 +1881,7 @@
                       },
                       "required": [
                         "BYTES_PER_ELEMENT",
-                        "__@toStringTag@570",
+                        "__@toStringTag@577",
                         "buffer",
                         "byteLength",
                         "byteOffset",
@@ -2075,7 +2075,7 @@
                         "BYTES_PER_ELEMENT": {
                           "type": "number"
                         },
-                        "__@toStringTag@570": {
+                        "__@toStringTag@577": {
                           "const": "Uint8Array",
                           "type": "string"
                         },
@@ -2094,7 +2094,7 @@
                       },
                       "required": [
                         "BYTES_PER_ELEMENT",
-                        "__@toStringTag@570",
+                        "__@toStringTag@577",
                         "buffer",
                         "byteLength",
                         "byteOffset",
@@ -2283,7 +2283,7 @@
                         "BYTES_PER_ELEMENT": {
                           "type": "number"
                         },
-                        "__@toStringTag@570": {
+                        "__@toStringTag@577": {
                           "const": "Uint8Array",
                           "type": "string"
                         },
@@ -2302,7 +2302,7 @@
                       },
                       "required": [
                         "BYTES_PER_ELEMENT",
-                        "__@toStringTag@570",
+                        "__@toStringTag@577",
                         "buffer",
                         "byteLength",
                         "byteOffset",
@@ -2511,7 +2511,7 @@
                 "BYTES_PER_ELEMENT": {
                   "type": "number"
                 },
-                "__@toStringTag@570": {
+                "__@toStringTag@577": {
                   "const": "Uint8Array",
                   "type": "string"
                 },
@@ -2530,7 +2530,7 @@
               },
               "required": [
                 "BYTES_PER_ELEMENT",
-                "__@toStringTag@570",
+                "__@toStringTag@577",
                 "buffer",
                 "byteLength",
                 "byteOffset",
@@ -2596,7 +2596,7 @@
                 "BYTES_PER_ELEMENT": {
                   "type": "number"
                 },
-                "__@toStringTag@570": {
+                "__@toStringTag@577": {
                   "const": "Uint8Array",
                   "type": "string"
                 },
@@ -2615,7 +2615,7 @@
               },
               "required": [
                 "BYTES_PER_ELEMENT",
-                "__@toStringTag@570",
+                "__@toStringTag@577",
                 "buffer",
                 "byteLength",
                 "byteOffset",
@@ -2923,10 +2923,10 @@
     },
     "SharedArrayBuffer": {
       "properties": {
-        "__@species@614": {
+        "__@species@621": {
           "$ref": "#/definitions/SharedArrayBuffer"
         },
-        "__@toStringTag@570": {
+        "__@toStringTag@577": {
           "const": "SharedArrayBuffer",
           "type": "string"
         },
@@ -2935,8 +2935,8 @@
         }
       },
       "required": [
-        "__@species@614",
-        "__@toStringTag@570",
+        "__@species@621",
+        "__@toStringTag@577",
         "byteLength"
       ],
       "type": "object"
@@ -2956,6 +2956,34 @@
         "plugin": {
           "description": "Plugin slug to test.\nWhen provided, runs plugin-specific tests including activation, deactivation, and load tests.",
           "type": "string"
+        },
+        "smokeTests": {
+          "anyOf": [
+            {
+              "properties": {
+                "exclude": {
+                  "description": "Run all smoke tests except these (mutually exclusive with include).\nUnknown test names are warned but don't fail - allows forward compatibility.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "include": {
+                  "description": "Only run these smoke tests (mutually exclusive with exclude).\nUnknown test names are warned but don't fail - allows forward compatibility.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "default": false,
+          "description": "Smoke tests configuration.\nWhen true, runs all applicable smoke tests.\nWhen an object, use include/exclude to filter specific tests.\nTakes precedence over the deprecated wp, plugin, and theme properties."
         },
         "theme": {
           "description": "Theme slug to test.\nWhen provided, runs theme-specific tests including activation and homepage load tests.",
@@ -3019,7 +3047,7 @@
                         "BYTES_PER_ELEMENT": {
                           "type": "number"
                         },
-                        "__@toStringTag@570": {
+                        "__@toStringTag@577": {
                           "const": "Uint8Array",
                           "type": "string"
                         },
@@ -3038,7 +3066,7 @@
                       },
                       "required": [
                         "BYTES_PER_ELEMENT",
-                        "__@toStringTag@570",
+                        "__@toStringTag@577",
                         "buffer",
                         "byteLength",
                         "byteOffset",
@@ -3262,7 +3290,7 @@
                 "BYTES_PER_ELEMENT": {
                   "type": "number"
                 },
-                "__@toStringTag@570": {
+                "__@toStringTag@577": {
                   "const": "Uint8Array",
                   "type": "string"
                 },
@@ -3281,7 +3309,7 @@
               },
               "required": [
                 "BYTES_PER_ELEMENT",
-                "__@toStringTag@570",
+                "__@toStringTag@577",
                 "buffer",
                 "byteLength",
                 "byteOffset",
@@ -3322,7 +3350,7 @@
                         "BYTES_PER_ELEMENT": {
                           "type": "number"
                         },
-                        "__@toStringTag@570": {
+                        "__@toStringTag@577": {
                           "const": "Uint8Array",
                           "type": "string"
                         },
@@ -3341,7 +3369,7 @@
                       },
                       "required": [
                         "BYTES_PER_ELEMENT",
-                        "__@toStringTag@570",
+                        "__@toStringTag@577",
                         "buffer",
                         "byteLength",
                         "byteOffset",

--- a/packages/config/src/smoke-tests-validation.ts
+++ b/packages/config/src/smoke-tests-validation.ts
@@ -1,0 +1,80 @@
+import type { SmokeTests } from "./wp-tester-config";
+
+/**
+ * Known smoke test names.
+ * Must be kept in sync with SMOKE_TEST_REGISTRY in @wp-tester/smoke-tests.
+ */
+export const KNOWN_SMOKE_TESTS: readonly string[] = [
+  // WordPress tests
+  "wpBoot",
+  "wpAdminLoads",
+  "wpRestApiAvailable",
+  // Plugin tests
+  "pluginActivates",
+  "pluginDeactivates",
+  "pluginLoads",
+  // Theme tests
+  "themeActivates",
+  "themeLoads",
+] as const;
+
+/**
+ * Result of validating smokeTests configuration.
+ */
+export interface SmokeTestsValidationResult {
+  /** Any warnings about unknown test names */
+  warnings: string[];
+}
+
+/**
+ * Validate smokeTests configuration.
+ *
+ * @param smokeTests - The smokeTests configuration to validate
+ * @returns Validation result with warnings
+ * @throws Error if include and exclude are both specified
+ */
+export function validateSmokeTests(
+  smokeTests: SmokeTests
+): SmokeTestsValidationResult {
+  const warnings: string[] = [];
+
+  // Boolean is always valid
+  if (typeof smokeTests === "boolean") {
+    return { warnings };
+  }
+
+  // Check for mutually exclusive include/exclude
+  const hasInclude = smokeTests.include !== undefined;
+  const hasExclude = smokeTests.exclude !== undefined;
+
+  if (hasInclude && hasExclude) {
+    throw new Error(
+      "smokeTests cannot have both 'include' and 'exclude'. Use one or the other."
+    );
+  }
+
+  // Check for unknown test names
+  const knownSet = new Set(KNOWN_SMOKE_TESTS);
+
+  if (smokeTests.include) {
+    for (const testName of smokeTests.include) {
+      if (!knownSet.has(testName)) {
+        warnings.push(
+          `Unknown smoke test '${testName}' in include. Available tests: ${KNOWN_SMOKE_TESTS.join(", ")}`
+        );
+      }
+    }
+  }
+
+  if (smokeTests.exclude) {
+    for (const testName of smokeTests.exclude) {
+      if (!knownSet.has(testName)) {
+        warnings.push(
+          `Unknown smoke test '${testName}' in exclude. Available tests: ${KNOWN_SMOKE_TESTS.join(", ")}`
+        );
+      }
+    }
+  }
+
+  return { warnings };
+}

--- a/packages/config/src/test-resolver.ts
+++ b/packages/config/src/test-resolver.ts
@@ -3,6 +3,7 @@ import type { ResolvedTests, ResolvedPHPUnitConfig, ResolvedPath } from "./resol
 import { resolveAbsolute, toResolvedPath } from "./path-utils";
 import { resolveBootstrapPath } from './options/phpunit-detect';
 import { hostToVfs } from './path-mappers';
+import { validateSmokeTests } from './smoke-tests-validation';
 
 /**
  * PHPUnit flags that are boolean (do not take a value).
@@ -84,9 +85,16 @@ export function resolvePhpunitArgs(args: string[], projectPath: ResolvedPath): s
  * @returns Resolved tests configuration
  */
 export async function resolveTests(tests: Tests, projectPath: ResolvedPath): Promise<ResolvedTests> {
+  // Validate smokeTests if present
+  if (tests.smokeTests !== undefined) {
+    // This will throw if include and exclude are both specified
+    validateSmokeTests(tests.smokeTests);
+  }
+
   // If no PHPUnit config, return tests as-is (but explicitly typed)
   if (!tests.phpunit) {
     return {
+      smokeTests: tests.smokeTests,
       plugin: tests.plugin,
       theme: tests.theme,
       wp: tests.wp,
@@ -118,6 +126,7 @@ export async function resolveTests(tests: Tests, projectPath: ResolvedPath): Pro
   }
 
   return {
+    smokeTests: tests.smokeTests,
     plugin: tests.plugin,
     theme: tests.theme,
     wp: tests.wp,

--- a/packages/config/src/test-resolver.ts
+++ b/packages/config/src/test-resolver.ts
@@ -1,9 +1,44 @@
-import type { Tests } from "./wp-tester-config";
+import type { Tests, ProjectType } from "./wp-tester-config";
 import type { ResolvedTests, ResolvedPHPUnitConfig, ResolvedPath } from "./resolved-types";
 import { resolveAbsolute, toResolvedPath } from "./path-utils";
 import { resolveBootstrapPath } from './options/phpunit-detect';
 import { hostToVfs } from './path-mappers';
 import { validateSmokeTests } from './smoke-tests-validation';
+
+/**
+ * Extract the plugin slug from a VFS path.
+ * Expected format: /wordpress/wp-content/plugins/<slug> or /wordpress/wp-content/plugins/<slug>/
+ */
+export function extractPluginSlug(vfsPath: string): string | undefined {
+  const match = vfsPath.match(/\/wp-content\/plugins\/([^/]+)/);
+  return match ? match[1] : undefined;
+}
+
+/**
+ * Extract the theme slug from a VFS path.
+ * Expected format: /wordpress/wp-content/themes/<slug> or /wordpress/wp-content/themes/<slug>/
+ */
+export function extractThemeSlug(vfsPath: string): string | undefined {
+  const match = vfsPath.match(/\/wp-content\/themes\/([^/]+)/);
+  return match ? match[1] : undefined;
+}
+
+/**
+ * Derive the project slug from VFS path based on project type.
+ * @param vfsPath - The VFS path where the project is mounted
+ * @param projectType - The project type (plugin, theme, etc.)
+ * @returns The derived slug or undefined if not derivable
+ */
+export function deriveProjectSlug(vfsPath: string, projectType: ProjectType): string | undefined {
+  switch (projectType) {
+    case 'plugin':
+      return extractPluginSlug(vfsPath);
+    case 'theme':
+      return extractThemeSlug(vfsPath);
+    default:
+      return undefined;
+  }
+}
 
 /**
  * PHPUnit flags that are boolean (do not take a value).
@@ -84,20 +119,20 @@ export function resolvePhpunitArgs(args: string[], projectPath: ResolvedPath): s
  * @param projectPath - Project path with host and VFS paths
  * @returns Resolved tests configuration
  */
-export async function resolveTests(tests: Tests, projectPath: ResolvedPath): Promise<ResolvedTests> {
+export async function resolveTests(
+  tests: Tests,
+  projectPath: ResolvedPath
+): Promise<ResolvedTests> {
   // Validate smokeTests if present
   if (tests.smokeTests !== undefined) {
     // This will throw if include and exclude are both specified
     validateSmokeTests(tests.smokeTests);
   }
 
-  // If no PHPUnit config, return tests as-is (but explicitly typed)
+  // If no PHPUnit config, return tests as-is
   if (!tests.phpunit) {
     return {
       smokeTests: tests.smokeTests,
-      plugin: tests.plugin,
-      theme: tests.theme,
-      wp: tests.wp,
       passWithNoTests: tests.passWithNoTests,
     };
   }
@@ -127,9 +162,6 @@ export async function resolveTests(tests: Tests, projectPath: ResolvedPath): Pro
 
   return {
     smokeTests: tests.smokeTests,
-    plugin: tests.plugin,
-    theme: tests.theme,
-    wp: tests.wp,
     phpunit: resolvedPhpunit,
     passWithNoTests: tests.passWithNoTests,
   };

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -5,6 +5,7 @@ export type {
   EnvironmentVariables,
   Environment,
   Tests,
+  SmokeTests,
   PHPUnitConfig,
   Reporters,
   BaseReporterOptions,

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -23,6 +23,7 @@ export type {
 
 /**
  * Individual test type that can be run.
- * Combines smoke test types (wp, plugin, theme) with PHPUnit tests.
+ * - "smoke": WordPress Playground smoke tests (wp, plugin, theme based on projectType)
+ * - "phpunit": PHPUnit tests
  */
-export type TestType = "wp" | "plugin" | "theme" | "phpunit";
+export type TestType = "smoke" | "phpunit";

--- a/packages/config/src/wp-tester-config.ts
+++ b/packages/config/src/wp-tester-config.ts
@@ -97,27 +97,73 @@ export interface PHPUnitConfig {
 }
 
 /**
+ * Smoke tests configuration.
+ * Controls which smoke tests to run.
+ *
+ * Plugin/theme tests are automatically enabled based on projectType.
+ * Use include/exclude to filter specific tests.
+ *
+ * @example
+ * // Run all applicable smoke tests (WP + plugin/theme based on projectType)
+ * smokeTests: true
+ *
+ * @example
+ * // Disable all smoke tests
+ * smokeTests: false
+ *
+ * @example
+ * // Run only specific tests
+ * smokeTests: { include: ["wpBoot", "pluginActivates"] }
+ *
+ * @example
+ * // Run all tests except specific ones
+ * smokeTests: { exclude: ["wpRestApiAvailable"] }
+ */
+export type SmokeTests =
+  | boolean
+  | {
+      /**
+       * Only run these smoke tests (mutually exclusive with exclude).
+       * Unknown test names are warned but don't fail - allows forward compatibility.
+       * @example ["wpBoot", "pluginActivates"]
+       */
+      include?: string[];
+      /**
+       * Run all smoke tests except these (mutually exclusive with include).
+       * Unknown test names are warned but don't fail - allows forward compatibility.
+       * @example ["wpRestApiAvailable"]
+       */
+      exclude?: string[];
+    };
+
+/**
  * Test configuration specifying which test suites to run.
  */
 export interface Tests {
   /**
+   * Smoke tests configuration.
+   * When true, runs all applicable smoke tests.
+   * When an object, use include/exclude to filter specific tests.
+   * Takes precedence over the deprecated wp, plugin, and theme properties.
+   * @default false
+   */
+  smokeTests?: SmokeTests;
+
+  /**
    * Plugin slug to test.
-   * When provided, runs plugin-specific tests including activation, deactivation, and load tests.
-   * @example "my-awesome-plugin"
+   * @deprecated Use smokeTests: { plugin: "my-plugin" } instead.
    */
   plugin?: string;
 
   /**
    * Theme slug to test.
-   * When provided, runs theme-specific tests including activation and homepage load tests.
-   * @example "my-custom-theme"
+   * @deprecated Use smokeTests: { theme: "my-theme" } instead.
    */
   theme?: string;
 
   /**
    * Whether to run WordPress core tests.
-   * Tests WordPress boot, admin dashboard, and REST API.
-   * @default false
+   * @deprecated Use smokeTests: true instead.
    */
   wp?: boolean;
 

--- a/packages/config/src/wp-tester-config.ts
+++ b/packages/config/src/wp-tester-config.ts
@@ -399,6 +399,15 @@ export interface WPTesterConfig {
   projectType?: ProjectType;
 
   /**
+   * Project slug (e.g., plugin or theme slug).
+   * If not specified, automatically derived from the project's VFS path.
+   * Used for smoke tests that activate/test specific plugins or themes.
+   * @example "my-plugin"
+   * @example "my-theme"
+   */
+  projectSlug?: string;
+
+  /**
    * Test environments to run.
    * Each environment can have different PHP/WordPress versions and setup.
    * Tests will run against all defined environments (matrix testing).

--- a/packages/config/tests/resolved-smoketests.spec.ts
+++ b/packages/config/tests/resolved-smoketests.spec.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { resolveConfig } from '../src';
+import type { WPTesterConfig } from '../src/wp-tester-config';
+
+describe('Resolved config - smokeTests', () => {
+  it('should pass through smokeTests boolean true', async () => {
+    const config: WPTesterConfig = {
+      projectType: 'plugin',
+      environments: [
+        {
+          blueprint: {
+            preferredVersions: {
+              php: '8.0',
+              wp: 'latest'
+            }
+          }
+        }
+      ],
+      tests: {
+        smokeTests: true,
+      }
+    };
+
+    const resolvedConfig = await resolveConfig(config);
+    expect(resolvedConfig.tests.smokeTests).toBe(true);
+  });
+
+  it('should pass through smokeTests boolean false', async () => {
+    const config: WPTesterConfig = {
+      projectType: 'plugin',
+      environments: [
+        {
+          blueprint: {
+            preferredVersions: {
+              php: '8.0',
+              wp: 'latest'
+            }
+          }
+        }
+      ],
+      tests: {
+        smokeTests: false,
+      }
+    };
+
+    const resolvedConfig = await resolveConfig(config);
+    expect(resolvedConfig.tests.smokeTests).toBe(false);
+  });
+
+  it('should pass through smokeTests with include', async () => {
+    const config: WPTesterConfig = {
+      projectType: 'plugin',
+      environments: [
+        {
+          blueprint: {
+            preferredVersions: {
+              php: '8.0',
+              wp: 'latest'
+            }
+          }
+        }
+      ],
+      tests: {
+        smokeTests: { include: ['wpBoot', 'wpAdminLoads'] },
+      }
+    };
+
+    const resolvedConfig = await resolveConfig(config);
+    expect(resolvedConfig.tests.smokeTests).toEqual({ include: ['wpBoot', 'wpAdminLoads'] });
+  });
+
+  it('should pass through smokeTests with exclude', async () => {
+    const config: WPTesterConfig = {
+      projectType: 'plugin',
+      environments: [
+        {
+          blueprint: {
+            preferredVersions: {
+              php: '8.0',
+              wp: 'latest'
+            }
+          }
+        }
+      ],
+      tests: {
+        smokeTests: { exclude: ['wpRestApiAvailable'] },
+      }
+    };
+
+    const resolvedConfig = await resolveConfig(config);
+    expect(resolvedConfig.tests.smokeTests).toEqual({ exclude: ['wpRestApiAvailable'] });
+  });
+
+  it('should throw error when both include and exclude are specified', async () => {
+    const config: WPTesterConfig = {
+      projectType: 'plugin',
+      environments: [
+        {
+          blueprint: {
+            preferredVersions: {
+              php: '8.0',
+              wp: 'latest'
+            }
+          }
+        }
+      ],
+      tests: {
+        smokeTests: {
+          include: ['wpBoot'],
+          exclude: ['wpAdminLoads'],
+        } as any, // Type system should prevent this but we test runtime
+      }
+    };
+
+    await expect(resolveConfig(config)).rejects.toThrow(
+      "smokeTests cannot have both 'include' and 'exclude'. Use one or the other."
+    );
+  });
+
+  it('should handle config without smokeTests (undefined)', async () => {
+    const config: WPTesterConfig = {
+      projectType: 'plugin',
+      environments: [
+        {
+          blueprint: {
+            preferredVersions: {
+              php: '8.0',
+              wp: 'latest'
+            }
+          }
+        }
+      ],
+      tests: {
+        wp: true,
+      }
+    };
+
+    const resolvedConfig = await resolveConfig(config);
+    expect(resolvedConfig.tests.smokeTests).toBeUndefined();
+  });
+});

--- a/packages/config/tests/slug-extraction.spec.ts
+++ b/packages/config/tests/slug-extraction.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { extractPluginSlug, extractThemeSlug, deriveProjectSlug } from '../src/test-resolver.js';
+
+describe('extractPluginSlug', () => {
+  it('should extract slug from standard plugin path', () => {
+    expect(extractPluginSlug('/wordpress/wp-content/plugins/my-plugin')).toBe('my-plugin');
+  });
+
+  it('should extract slug from plugin path with trailing slash', () => {
+    expect(extractPluginSlug('/wordpress/wp-content/plugins/my-plugin/')).toBe('my-plugin');
+  });
+
+  it('should extract slug from deeply nested plugin path', () => {
+    expect(extractPluginSlug('/wordpress/wp-content/plugins/my-plugin/src/includes')).toBe('my-plugin');
+  });
+
+  it('should return undefined for non-plugin paths', () => {
+    expect(extractPluginSlug('/wordpress/wp-content/themes/my-theme')).toBeUndefined();
+  });
+
+  it('should return undefined for root wordpress path', () => {
+    expect(extractPluginSlug('/wordpress')).toBeUndefined();
+  });
+
+  it('should return undefined for wp-content path', () => {
+    expect(extractPluginSlug('/wordpress/wp-content')).toBeUndefined();
+  });
+});
+
+describe('extractThemeSlug', () => {
+  it('should extract slug from standard theme path', () => {
+    expect(extractThemeSlug('/wordpress/wp-content/themes/my-theme')).toBe('my-theme');
+  });
+
+  it('should extract slug from theme path with trailing slash', () => {
+    expect(extractThemeSlug('/wordpress/wp-content/themes/my-theme/')).toBe('my-theme');
+  });
+
+  it('should extract slug from deeply nested theme path', () => {
+    expect(extractThemeSlug('/wordpress/wp-content/themes/my-theme/template-parts')).toBe('my-theme');
+  });
+
+  it('should return undefined for non-theme paths', () => {
+    expect(extractThemeSlug('/wordpress/wp-content/plugins/my-plugin')).toBeUndefined();
+  });
+
+  it('should return undefined for root wordpress path', () => {
+    expect(extractThemeSlug('/wordpress')).toBeUndefined();
+  });
+
+  it('should return undefined for wp-content path', () => {
+    expect(extractThemeSlug('/wordpress/wp-content')).toBeUndefined();
+  });
+});
+
+describe('deriveProjectSlug', () => {
+  it('should derive plugin slug when projectType is plugin', () => {
+    expect(deriveProjectSlug('/wordpress/wp-content/plugins/my-plugin', 'plugin')).toBe('my-plugin');
+  });
+
+  it('should derive theme slug when projectType is theme', () => {
+    expect(deriveProjectSlug('/wordpress/wp-content/themes/my-theme', 'theme')).toBe('my-theme');
+  });
+
+  it('should return undefined for plugin path when projectType is theme', () => {
+    expect(deriveProjectSlug('/wordpress/wp-content/plugins/my-plugin', 'theme')).toBeUndefined();
+  });
+
+  it('should return undefined for theme path when projectType is plugin', () => {
+    expect(deriveProjectSlug('/wordpress/wp-content/themes/my-theme', 'plugin')).toBeUndefined();
+  });
+
+  it('should return undefined for wordpress projectType', () => {
+    expect(deriveProjectSlug('/wordpress', 'wordpress')).toBeUndefined();
+  });
+
+  it('should return undefined for wp-content projectType', () => {
+    expect(deriveProjectSlug('/wordpress/wp-content', 'wp-content')).toBeUndefined();
+  });
+
+  it('should return undefined for other projectType', () => {
+    expect(deriveProjectSlug('/project', 'other')).toBeUndefined();
+  });
+});

--- a/packages/config/tests/smoke-tests-validation.spec.ts
+++ b/packages/config/tests/smoke-tests-validation.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { validateSmokeTests, KNOWN_SMOKE_TESTS } from '../src/smoke-tests-validation';
+import type { SmokeTests } from '../src/types';
+
+describe('validateSmokeTests', () => {
+  describe('valid configurations', () => {
+    it('should accept boolean true', () => {
+      expect(() => validateSmokeTests(true)).not.toThrow();
+    });
+
+    it('should accept boolean false', () => {
+      expect(() => validateSmokeTests(false)).not.toThrow();
+    });
+
+    it('should accept empty object', () => {
+      expect(() => validateSmokeTests({})).not.toThrow();
+    });
+
+    it('should accept object with only include', () => {
+      expect(() => validateSmokeTests({ include: ['wpBoot'] })).not.toThrow();
+    });
+
+    it('should accept object with only exclude', () => {
+      expect(() => validateSmokeTests({ exclude: ['wpBoot'] })).not.toThrow();
+    });
+
+    it('should accept empty include array', () => {
+      expect(() => validateSmokeTests({ include: [] })).not.toThrow();
+    });
+
+    it('should accept empty exclude array', () => {
+      expect(() => validateSmokeTests({ exclude: [] })).not.toThrow();
+    });
+  });
+
+  describe('mutually exclusive include/exclude', () => {
+    it('should throw when both include and exclude are specified', () => {
+      const config: SmokeTests = {
+        include: ['wpBoot'],
+        exclude: ['wpAdminLoads'],
+      };
+      expect(() => validateSmokeTests(config)).toThrow(
+        "smokeTests cannot have both 'include' and 'exclude'. Use one or the other."
+      );
+    });
+
+    it('should throw even when both arrays are empty', () => {
+      const config: SmokeTests = {
+        include: [],
+        exclude: [],
+      };
+      expect(() => validateSmokeTests(config)).toThrow(
+        "smokeTests cannot have both 'include' and 'exclude'. Use one or the other."
+      );
+    });
+  });
+
+  describe('unknown test name warnings', () => {
+    it('should return warnings for unknown test names in include', () => {
+      const result = validateSmokeTests({ include: ['wpBoot', 'unknownTest'] });
+      expect(result.warnings).toContain(
+        "Unknown smoke test 'unknownTest' in include. Available tests: " + KNOWN_SMOKE_TESTS.join(', ')
+      );
+    });
+
+    it('should return warnings for unknown test names in exclude', () => {
+      const result = validateSmokeTests({ exclude: ['wpBoot', 'anotherUnknown'] });
+      expect(result.warnings).toContain(
+        "Unknown smoke test 'anotherUnknown' in exclude. Available tests: " + KNOWN_SMOKE_TESTS.join(', ')
+      );
+    });
+
+    it('should not warn for valid test names', () => {
+      const result = validateSmokeTests({ include: ['wpBoot', 'wpAdminLoads'] });
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it('should return empty warnings for boolean config', () => {
+      const result = validateSmokeTests(true);
+      expect(result.warnings).toHaveLength(0);
+    });
+  });
+});
+
+describe('KNOWN_SMOKE_TESTS', () => {
+  it('should export the list of known smoke test names', () => {
+    expect(KNOWN_SMOKE_TESTS).toContain('wpBoot');
+    expect(KNOWN_SMOKE_TESTS).toContain('wpAdminLoads');
+    expect(KNOWN_SMOKE_TESTS).toContain('wpRestApiAvailable');
+    expect(KNOWN_SMOKE_TESTS).toContain('pluginActivates');
+    expect(KNOWN_SMOKE_TESTS).toContain('pluginDeactivates');
+    expect(KNOWN_SMOKE_TESTS).toContain('pluginLoads');
+    expect(KNOWN_SMOKE_TESTS).toContain('themeActivates');
+    expect(KNOWN_SMOKE_TESTS).toContain('themeLoads');
+  });
+});

--- a/packages/smoke-tests/src/index.ts
+++ b/packages/smoke-tests/src/index.ts
@@ -7,7 +7,7 @@
 import { startVitest, parseCLI, type Reporter } from "vitest/node";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { WPTesterConfig, Tests, TestType, ResolvedWPTesterConfig, ResolvedTests, SmokeTests } from "@wp-tester/config";
+import type { WPTesterConfig, ResolvedWPTesterConfig, SmokeTests } from "@wp-tester/config";
 import {
   EMPTY_REPORT,
   VitestStreamingReporter,
@@ -201,30 +201,17 @@ export function shouldRunSmokeTests(config: WPTesterConfig | ResolvedWPTesterCon
 /**
  * Select test files based on test configuration
  * @param config - Full configuration (needed for projectType)
- * @param test - Optional filter to run only specific test type (wp, plugin, or theme)
  * @returns Array of test file paths relative to package root
  * @throws Error if no test files match configuration
  */
 export function selectTestFiles(
-  config: WPTesterConfig | ResolvedWPTesterConfig,
-  test?: TestType | false
+  config: WPTesterConfig | ResolvedWPTesterConfig
 ): string[] {
-  if (test === false) {
-    return [];
-  }
-
   const { tests } = config;
 
   // Map spec file names to full paths
   const specToPath = (specName: string): string =>
     `${TEST_DIR}/smoke-tests/${specName}.${TEST_EXT}`;
-
-  // Map category to spec file
-  const categoryToSpec: Record<SmokeTestCategory, string> = {
-    wp: "wp.spec",
-    plugin: "plugin.spec",
-    theme: "theme.spec",
-  };
 
   let specFiles: Set<string>;
 
@@ -233,16 +220,6 @@ export function selectTestFiles(
     specFiles = getSpecFilesFromSmokeTests(tests.smokeTests, config);
   } else {
     specFiles = new Set<string>();
-  }
-
-  // Apply test type filter if specified
-  if (test) {
-    const filteredSpec = categoryToSpec[test as SmokeTestCategory];
-    if (filteredSpec && specFiles.has(filteredSpec)) {
-      specFiles = new Set([filteredSpec]);
-    } else {
-      specFiles = new Set();
-    }
   }
 
   const files = Array.from(specFiles).map(specToPath);
@@ -258,14 +235,12 @@ export function selectTestFiles(
  * Run WordPress smoke tests
  *
  * @param config - Resolved test configuration
- * @param test - Optional filter to run only specific test type (wp, plugin, or theme)
  * @param vitestArgs - Additional arguments to pass to Vitest CLI
  * @param sharedReporter - Optional shared streaming reporter for unified output
  * @returns CTRF report with test results
  */
 export async function runSmokeTests(
   config: ResolvedWPTesterConfig,
-  test?: TestType | false,
   vitestArgs?: string[],
   sharedReporter?: StreamingReporter
 ): Promise<Report> {
@@ -279,8 +254,8 @@ export async function runSmokeTests(
   const __dirname = dirname(__filename);
   const packageRoot = join(__dirname, "..");
 
-  // Select test files based on config and filter
-  const testFiles = selectTestFiles(config, test);
+  // Select test files based on config
+  const testFiles = selectTestFiles(config);
 
   if (testFiles.length === 0) {
     return Promise.resolve(EMPTY_REPORT);

--- a/packages/smoke-tests/src/index.ts
+++ b/packages/smoke-tests/src/index.ts
@@ -110,11 +110,11 @@ function isCategoryApplicable(
     case "wp":
       return true; // WP tests are always applicable
     case "plugin":
-      // Plugin tests run when projectType is "plugin" OR legacy tests.plugin is set
-      return config.projectType === "plugin" || config.tests.plugin !== undefined;
+      // Plugin tests run when projectType is "plugin"
+      return config.projectType === "plugin";
     case "theme":
-      // Theme tests run when projectType is "theme" OR legacy tests.theme is set
-      return config.projectType === "theme" || config.tests.theme !== undefined;
+      // Theme tests run when projectType is "theme"
+      return config.projectType === "theme";
     default:
       return false;
   }
@@ -184,22 +184,18 @@ function getSpecFilesFromSmokeTests(
 export function shouldRunSmokeTests(config: WPTesterConfig | ResolvedWPTesterConfig): boolean {
   const { tests } = config;
 
-  // If smokeTests is explicitly set, use it
-  if (tests.smokeTests !== undefined) {
-    if (typeof tests.smokeTests === "boolean") {
-      return tests.smokeTests;
-    }
-    // Object form - check if any tests would run
-    const specFiles = getSpecFilesFromSmokeTests(tests.smokeTests, config);
-    return specFiles.size > 0;
+  // smokeTests must be explicitly set
+  if (tests.smokeTests === undefined) {
+    return false;
   }
 
-  // Legacy behavior: check wp/plugin/theme
-  return (
-    tests.wp === true ||
-    tests.plugin !== undefined ||
-    tests.theme !== undefined
-  );
+  if (typeof tests.smokeTests === "boolean") {
+    return tests.smokeTests;
+  }
+
+  // Object form - check if any tests would run
+  const specFiles = getSpecFilesFromSmokeTests(tests.smokeTests, config);
+  return specFiles.size > 0;
 }
 
 /**
@@ -232,22 +228,11 @@ export function selectTestFiles(
 
   let specFiles: Set<string>;
 
-  // If smokeTests is explicitly set, use the new logic
+  // smokeTests must be explicitly set
   if (tests.smokeTests !== undefined) {
     specFiles = getSpecFilesFromSmokeTests(tests.smokeTests, config);
   } else {
-    // Legacy behavior: check wp/plugin/theme properties
     specFiles = new Set<string>();
-
-    if (tests.wp) {
-      specFiles.add(categoryToSpec.wp);
-    }
-    if (tests.plugin) {
-      specFiles.add(categoryToSpec.plugin);
-    }
-    if (tests.theme) {
-      specFiles.add(categoryToSpec.theme);
-    }
   }
 
   // Apply test type filter if specified

--- a/packages/smoke-tests/src/index.ts
+++ b/packages/smoke-tests/src/index.ts
@@ -7,7 +7,7 @@
 import { startVitest, parseCLI, type Reporter } from "vitest/node";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { WPTesterConfig, Tests, TestType, ResolvedWPTesterConfig, ResolvedTests } from "@wp-tester/config";
+import type { WPTesterConfig, Tests, TestType, ResolvedWPTesterConfig, ResolvedTests, SmokeTests } from "@wp-tester/config";
 import {
   EMPTY_REPORT,
   VitestStreamingReporter,
@@ -23,39 +23,244 @@ const TEST_DIR = "src";
 const TEST_EXT = "ts";
 const CONFIG_FILE = "src/smoke-tests/vitest.config.ts";
 
+/**
+ * Smoke test category - determines when a test is applicable
+ */
+export type SmokeTestCategory = "wp" | "plugin" | "theme";
+
+/**
+ * Smoke test definition
+ */
+export interface SmokeTestDefinition {
+  /** Category determines applicability (wp tests always run, plugin/theme require config) */
+  category: SmokeTestCategory;
+  /** Human-readable description */
+  description: string;
+  /** The spec file containing this test */
+  specFile: string;
+}
+
+/**
+ * Registry of all known smoke tests.
+ * New tests can be added here without schema changes.
+ */
+export const SMOKE_TEST_REGISTRY: Record<string, SmokeTestDefinition> = {
+  // WordPress tests (always applicable)
+  wpBoot: {
+    category: "wp",
+    description: "WordPress boots without fatal errors",
+    specFile: "wp.spec",
+  },
+  wpAdminLoads: {
+    category: "wp",
+    description: "WP Admin dashboard loads",
+    specFile: "wp.spec",
+  },
+  wpRestApiAvailable: {
+    category: "wp",
+    description: "REST API responds",
+    specFile: "wp.spec",
+  },
+
+  // Plugin tests (require tests.plugin to be set)
+  pluginActivates: {
+    category: "plugin",
+    description: "Plugin activates without errors",
+    specFile: "plugin.spec",
+  },
+  pluginDeactivates: {
+    category: "plugin",
+    description: "Plugin deactivates without errors",
+    specFile: "plugin.spec",
+  },
+  pluginLoads: {
+    category: "plugin",
+    description: "Pages load with plugin active",
+    specFile: "plugin.spec",
+  },
+
+  // Theme tests (require tests.theme to be set)
+  themeActivates: {
+    category: "theme",
+    description: "Theme activates without errors",
+    specFile: "theme.spec",
+  },
+  themeLoads: {
+    category: "theme",
+    description: "Pages load with theme active",
+    specFile: "theme.spec",
+  },
+};
+
+/**
+ * Get all known smoke test names
+ */
+export function getKnownSmokeTestNames(): string[] {
+  return Object.keys(SMOKE_TEST_REGISTRY);
+}
+
+/**
+ * Check if a category is applicable based on config
+ */
+function isCategoryApplicable(
+  category: SmokeTestCategory,
+  config: WPTesterConfig | ResolvedWPTesterConfig
+): boolean {
+  switch (category) {
+    case "wp":
+      return true; // WP tests are always applicable
+    case "plugin":
+      // Plugin tests run when projectType is "plugin" OR legacy tests.plugin is set
+      return config.projectType === "plugin" || config.tests.plugin !== undefined;
+    case "theme":
+      // Theme tests run when projectType is "theme" OR legacy tests.theme is set
+      return config.projectType === "theme" || config.tests.theme !== undefined;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Get the spec files to run based on smokeTests configuration
+ */
+function getSpecFilesFromSmokeTests(
+  smokeTests: SmokeTests,
+  config: WPTesterConfig | ResolvedWPTesterConfig
+): Set<string> {
+  const specFiles = new Set<string>();
+
+  // Handle boolean
+  if (typeof smokeTests === "boolean") {
+    if (!smokeTests) {
+      return specFiles; // Empty set - no tests
+    }
+    // true means run all applicable tests
+    for (const [, def] of Object.entries(SMOKE_TEST_REGISTRY)) {
+      if (isCategoryApplicable(def.category, config)) {
+        specFiles.add(def.specFile);
+      }
+    }
+    return specFiles;
+  }
+
+  // Handle object with include/exclude
+  const { include, exclude } = smokeTests;
+
+  if (include && include.length > 0) {
+    // Only run included tests (that are applicable)
+    for (const testName of include) {
+      const def = SMOKE_TEST_REGISTRY[testName];
+      if (def && isCategoryApplicable(def.category, config)) {
+        specFiles.add(def.specFile);
+      }
+      // Unknown test names are silently skipped (forward compatibility)
+    }
+  } else if (exclude && exclude.length > 0) {
+    // Run all applicable tests except excluded ones
+    const excludedSpecFiles = new Set<string>();
+    for (const testName of exclude) {
+      const def = SMOKE_TEST_REGISTRY[testName];
+      if (def) {
+        excludedSpecFiles.add(def.specFile);
+      }
+    }
+    for (const [, def] of Object.entries(SMOKE_TEST_REGISTRY)) {
+      if (isCategoryApplicable(def.category, config) && !excludedSpecFiles.has(def.specFile)) {
+        specFiles.add(def.specFile);
+      }
+    }
+  } else {
+    // Empty object {} means run all applicable tests (same as true)
+    for (const [, def] of Object.entries(SMOKE_TEST_REGISTRY)) {
+      if (isCategoryApplicable(def.category, config)) {
+        specFiles.add(def.specFile);
+      }
+    }
+  }
+
+  return specFiles;
+}
+
 export function shouldRunSmokeTests(config: WPTesterConfig | ResolvedWPTesterConfig): boolean {
+  const { tests } = config;
+
+  // If smokeTests is explicitly set, use it
+  if (tests.smokeTests !== undefined) {
+    if (typeof tests.smokeTests === "boolean") {
+      return tests.smokeTests;
+    }
+    // Object form - check if any tests would run
+    const specFiles = getSpecFilesFromSmokeTests(tests.smokeTests, config);
+    return specFiles.size > 0;
+  }
+
+  // Legacy behavior: check wp/plugin/theme
   return (
-    config.tests.wp === true ||
-    config.tests.plugin !== undefined ||
-    config.tests.theme !== undefined
+    tests.wp === true ||
+    tests.plugin !== undefined ||
+    tests.theme !== undefined
   );
 }
 
 /**
  * Select test files based on test configuration
- * @param tests - Test configuration
+ * @param config - Full configuration (needed for projectType)
  * @param test - Optional filter to run only specific test type (wp, plugin, or theme)
  * @returns Array of test file paths relative to package root
  * @throws Error if no test files match configuration
  */
 export function selectTestFiles(
-  tests: Tests | ResolvedTests,
+  config: WPTesterConfig | ResolvedWPTesterConfig,
   test?: TestType | false
 ): string[] {
   if (test === false) {
     return [];
   }
 
-  const testConfigs: Array<{ type: keyof Tests; path: string }> = [
-    { type: "wp", path: `${TEST_DIR}/smoke-tests/wp.spec.${TEST_EXT}` },
-    { type: "plugin", path: `${TEST_DIR}/smoke-tests/plugin.spec.${TEST_EXT}` },
-    { type: "theme", path: `${TEST_DIR}/smoke-tests/theme.spec.${TEST_EXT}` },
-  ];
+  const { tests } = config;
 
-  const files = testConfigs
-    .filter(({ type }) => !test || type === test)
-    .filter(({ type }) => tests[type])
-    .map(({ path }) => path);
+  // Map spec file names to full paths
+  const specToPath = (specName: string): string =>
+    `${TEST_DIR}/smoke-tests/${specName}.${TEST_EXT}`;
+
+  // Map category to spec file
+  const categoryToSpec: Record<SmokeTestCategory, string> = {
+    wp: "wp.spec",
+    plugin: "plugin.spec",
+    theme: "theme.spec",
+  };
+
+  let specFiles: Set<string>;
+
+  // If smokeTests is explicitly set, use the new logic
+  if (tests.smokeTests !== undefined) {
+    specFiles = getSpecFilesFromSmokeTests(tests.smokeTests, config);
+  } else {
+    // Legacy behavior: check wp/plugin/theme properties
+    specFiles = new Set<string>();
+
+    if (tests.wp) {
+      specFiles.add(categoryToSpec.wp);
+    }
+    if (tests.plugin) {
+      specFiles.add(categoryToSpec.plugin);
+    }
+    if (tests.theme) {
+      specFiles.add(categoryToSpec.theme);
+    }
+  }
+
+  // Apply test type filter if specified
+  if (test) {
+    const filteredSpec = categoryToSpec[test as SmokeTestCategory];
+    if (filteredSpec && specFiles.has(filteredSpec)) {
+      specFiles = new Set([filteredSpec]);
+    } else {
+      specFiles = new Set();
+    }
+  }
+
+  const files = Array.from(specFiles).map(specToPath);
 
   if (files.length === 0) {
     throw new Error("No test files selected. Check your tests configuration.");
@@ -90,7 +295,7 @@ export async function runSmokeTests(
   const packageRoot = join(__dirname, "..");
 
   // Select test files based on config and filter
-  const testFiles = selectTestFiles(config.tests, test);
+  const testFiles = selectTestFiles(config, test);
 
   if (testFiles.length === 0) {
     return Promise.resolve(EMPTY_REPORT);

--- a/packages/smoke-tests/src/smoke-tests/plugin.spec.ts
+++ b/packages/smoke-tests/src/smoke-tests/plugin.spec.ts
@@ -6,7 +6,8 @@ import { startPlayground, stopPlayground, wpCli, type RunCLIServer } from '@wp-t
 const config = inject('config') as ResolvedWPTesterConfig;
 // Filter out skipped environments
 const environments = config.environments.filter(env => !env.skip);
-const pluginSlug = config.tests.plugin;
+// Get the project slug from resolved config (used as plugin slug)
+const pluginSlug = config.projectSlug;
 
 // Test each environment
 if (pluginSlug) {

--- a/packages/smoke-tests/src/smoke-tests/theme.spec.ts
+++ b/packages/smoke-tests/src/smoke-tests/theme.spec.ts
@@ -6,7 +6,8 @@ import { startPlayground, stopPlayground, wpCli, type RunCLIServer } from '@wp-t
 const config = inject('config') as ResolvedWPTesterConfig;
 // Filter out skipped environments
 const environments = config.environments.filter(env => !env.skip);
-const themeSlug = config.tests.theme;
+// Get the project slug from resolved config (used as theme slug)
+const themeSlug = config.projectSlug;
 
 // Skip all tests if no theme is configured
 if (themeSlug) {

--- a/packages/smoke-tests/tests/integration/run-smoke-tests.spec.ts
+++ b/packages/smoke-tests/tests/integration/run-smoke-tests.spec.ts
@@ -17,7 +17,7 @@ describe("runSmokeTests integration", () => {
         },
       ],
       tests: {
-        wp: true,
+        smokeTests: true,
       },
     };
 

--- a/packages/smoke-tests/tests/test-selection.spec.ts
+++ b/packages/smoke-tests/tests/test-selection.spec.ts
@@ -12,40 +12,10 @@ function createConfig(overrides: Partial<WPTesterConfig> = {}): WPTesterConfig {
 }
 
 describe('selectTestFiles', () => {
-  describe('legacy tests.wp/plugin/theme (deprecated)', () => {
-    it('should select wp.spec.ts when tests.wp is true', () => {
-      const config = createConfig({ tests: { wp: true } });
-      const files = selectTestFiles(config);
-      expect(files).toEqual(['src/smoke-tests/wp.spec.ts']);
-    });
-
+  describe('no smokeTests configured', () => {
     it('should throw error when no tests are configured', () => {
       const config = createConfig({ tests: {} });
       expect(() => selectTestFiles(config)).toThrow('No test files selected');
-    });
-
-    it('should throw error when wp is false', () => {
-      const config = createConfig({ tests: { wp: false } });
-      expect(() => selectTestFiles(config)).toThrow('No test files selected');
-    });
-
-    it('should select plugin.spec.ts when tests.plugin is set (legacy)', () => {
-      const config = createConfig({ tests: { plugin: 'my-plugin' } });
-      const files = selectTestFiles(config);
-      expect(files).toEqual(['src/smoke-tests/plugin.spec.ts']);
-    });
-
-    it('should select theme.spec.ts when tests.theme is set (legacy)', () => {
-      const config = createConfig({ tests: { theme: 'my-theme' } });
-      const files = selectTestFiles(config);
-      expect(files).toEqual(['src/smoke-tests/theme.spec.ts']);
-    });
-
-    it('should select multiple test files when multiple are configured', () => {
-      const config = createConfig({ tests: { wp: true, plugin: 'my-plugin' } });
-      const files = selectTestFiles(config);
-      expect(files).toContain('src/smoke-tests/wp.spec.ts');
-      expect(files).toContain('src/smoke-tests/plugin.spec.ts');
     });
   });
 
@@ -169,30 +139,15 @@ describe('selectTestFiles', () => {
     });
   });
 
-  describe('smokeTests overrides legacy properties', () => {
-    it('should use smokeTests when both smokeTests and legacy wp are set', () => {
+  describe('smokeTests: false explicitly set', () => {
+    it('should throw error when smokeTests is false', () => {
       const config = createConfig({
+        projectType: 'plugin',
         tests: {
           smokeTests: false,
-          wp: true, // This should be ignored when smokeTests is explicitly set
         },
       });
       expect(() => selectTestFiles(config)).toThrow('No test files selected');
-    });
-
-    it('should use projectType over legacy tests.plugin', () => {
-      const config = createConfig({
-        projectType: 'theme', // This takes precedence
-        tests: {
-          smokeTests: true,
-          plugin: 'my-plugin', // Legacy, should be ignored for applicability
-        },
-      });
-      const files = selectTestFiles(config);
-      expect(files).toContain('src/smoke-tests/wp.spec.ts');
-      expect(files).toContain('src/smoke-tests/theme.spec.ts');
-      // Plugin tests should also run because tests.plugin is set (legacy fallback)
-      expect(files).toContain('src/smoke-tests/plugin.spec.ts');
     });
   });
 });

--- a/packages/smoke-tests/tests/test-selection.spec.ts
+++ b/packages/smoke-tests/tests/test-selection.spec.ts
@@ -1,21 +1,225 @@
 import { describe, it, expect } from 'vitest';
-import { selectTestFiles } from '../src/index.js';
-import type { Tests } from '@wp-tester/config';
+import { selectTestFiles, SMOKE_TEST_REGISTRY } from '../src/index.js';
+import type { WPTesterConfig } from '@wp-tester/config';
+
+// Helper to create a minimal config for testing
+function createConfig(overrides: Partial<WPTesterConfig> = {}): WPTesterConfig {
+  return {
+    environments: [{ php: ['8.2'], wp: ['6.7'] }],
+    tests: {},
+    ...overrides,
+  };
+}
 
 describe('selectTestFiles', () => {
-  it('should select wp.spec.ts when tests.wp is true', () => {
-    const tests: Tests = { wp: true };
-    const files = selectTestFiles(tests);
-    expect(files).toEqual(['src/smoke-tests/wp.spec.ts']);
+  describe('legacy tests.wp/plugin/theme (deprecated)', () => {
+    it('should select wp.spec.ts when tests.wp is true', () => {
+      const config = createConfig({ tests: { wp: true } });
+      const files = selectTestFiles(config);
+      expect(files).toEqual(['src/smoke-tests/wp.spec.ts']);
+    });
+
+    it('should throw error when no tests are configured', () => {
+      const config = createConfig({ tests: {} });
+      expect(() => selectTestFiles(config)).toThrow('No test files selected');
+    });
+
+    it('should throw error when wp is false', () => {
+      const config = createConfig({ tests: { wp: false } });
+      expect(() => selectTestFiles(config)).toThrow('No test files selected');
+    });
+
+    it('should select plugin.spec.ts when tests.plugin is set (legacy)', () => {
+      const config = createConfig({ tests: { plugin: 'my-plugin' } });
+      const files = selectTestFiles(config);
+      expect(files).toEqual(['src/smoke-tests/plugin.spec.ts']);
+    });
+
+    it('should select theme.spec.ts when tests.theme is set (legacy)', () => {
+      const config = createConfig({ tests: { theme: 'my-theme' } });
+      const files = selectTestFiles(config);
+      expect(files).toEqual(['src/smoke-tests/theme.spec.ts']);
+    });
+
+    it('should select multiple test files when multiple are configured', () => {
+      const config = createConfig({ tests: { wp: true, plugin: 'my-plugin' } });
+      const files = selectTestFiles(config);
+      expect(files).toContain('src/smoke-tests/wp.spec.ts');
+      expect(files).toContain('src/smoke-tests/plugin.spec.ts');
+    });
   });
 
-  it('should throw error when no tests are configured', () => {
-    const tests: Tests = {};
-    expect(() => selectTestFiles(tests)).toThrow('No test files selected');
+  describe('smokeTests with projectType', () => {
+    it('should run wp + plugin tests when projectType is plugin and smokeTests is true', () => {
+      const config = createConfig({
+        projectType: 'plugin',
+        tests: { smokeTests: true },
+      });
+      const files = selectTestFiles(config);
+      expect(files).toContain('src/smoke-tests/wp.spec.ts');
+      expect(files).toContain('src/smoke-tests/plugin.spec.ts');
+      expect(files).not.toContain('src/smoke-tests/theme.spec.ts');
+    });
+
+    it('should run wp + theme tests when projectType is theme and smokeTests is true', () => {
+      const config = createConfig({
+        projectType: 'theme',
+        tests: { smokeTests: true },
+      });
+      const files = selectTestFiles(config);
+      expect(files).toContain('src/smoke-tests/wp.spec.ts');
+      expect(files).toContain('src/smoke-tests/theme.spec.ts');
+      expect(files).not.toContain('src/smoke-tests/plugin.spec.ts');
+    });
+
+    it('should run only wp tests when projectType is wordpress and smokeTests is true', () => {
+      const config = createConfig({
+        projectType: 'wordpress',
+        tests: { smokeTests: true },
+      });
+      const files = selectTestFiles(config);
+      expect(files).toEqual(['src/smoke-tests/wp.spec.ts']);
+    });
+
+    it('should run only wp tests when projectType is other and smokeTests is true', () => {
+      const config = createConfig({
+        projectType: 'other',
+        tests: { smokeTests: true },
+      });
+      const files = selectTestFiles(config);
+      expect(files).toEqual(['src/smoke-tests/wp.spec.ts']);
+    });
   });
 
-  it('should throw error when wp is false', () => {
-    const tests: Tests = { wp: false };
-    expect(() => selectTestFiles(tests)).toThrow('No test files selected');
+  describe('smokeTests: boolean', () => {
+    it('should run no tests when smokeTests is false', () => {
+      const config = createConfig({ tests: { smokeTests: false } });
+      expect(() => selectTestFiles(config)).toThrow('No test files selected');
+    });
+
+    it('should run only wp tests when smokeTests is true with no projectType', () => {
+      const config = createConfig({ tests: { smokeTests: true } });
+      const files = selectTestFiles(config);
+      expect(files).toEqual(['src/smoke-tests/wp.spec.ts']);
+    });
+  });
+
+  describe('smokeTests: { include }', () => {
+    it('should run only included tests', () => {
+      const config = createConfig({
+        projectType: 'plugin',
+        tests: { smokeTests: { include: ['wpBoot'] } },
+      });
+      const files = selectTestFiles(config);
+      expect(files).toEqual(['src/smoke-tests/wp.spec.ts']);
+    });
+
+    it('should run multiple included tests', () => {
+      const config = createConfig({
+        projectType: 'plugin',
+        tests: { smokeTests: { include: ['wpBoot', 'pluginActivates'] } },
+      });
+      const files = selectTestFiles(config);
+      expect(files).toContain('src/smoke-tests/wp.spec.ts');
+      expect(files).toContain('src/smoke-tests/plugin.spec.ts');
+    });
+
+    it('should silently skip inapplicable tests in include', () => {
+      const config = createConfig({
+        projectType: 'wordpress', // Not a plugin project
+        tests: { smokeTests: { include: ['wpBoot', 'pluginActivates'] } },
+      });
+      const files = selectTestFiles(config);
+      // pluginActivates should be skipped since projectType is not plugin
+      expect(files).toEqual(['src/smoke-tests/wp.spec.ts']);
+    });
+  });
+
+  describe('smokeTests: { exclude }', () => {
+    it('should run all except excluded tests', () => {
+      const config = createConfig({
+        projectType: 'plugin',
+        tests: { smokeTests: { exclude: ['pluginActivates', 'pluginDeactivates', 'pluginLoads'] } },
+      });
+      const files = selectTestFiles(config);
+      expect(files).toContain('src/smoke-tests/wp.spec.ts');
+      expect(files).not.toContain('src/smoke-tests/plugin.spec.ts');
+    });
+
+    it('should run all tests when exclude is empty', () => {
+      const config = createConfig({
+        projectType: 'plugin',
+        tests: { smokeTests: { exclude: [] } },
+      });
+      const files = selectTestFiles(config);
+      expect(files).toContain('src/smoke-tests/wp.spec.ts');
+      expect(files).toContain('src/smoke-tests/plugin.spec.ts');
+    });
+  });
+
+  describe('smokeTests: {}', () => {
+    it('should run all applicable tests when smokeTests is empty object', () => {
+      const config = createConfig({
+        projectType: 'plugin',
+        tests: { smokeTests: {} },
+      });
+      const files = selectTestFiles(config);
+      expect(files).toContain('src/smoke-tests/wp.spec.ts');
+      expect(files).toContain('src/smoke-tests/plugin.spec.ts');
+    });
+  });
+
+  describe('smokeTests overrides legacy properties', () => {
+    it('should use smokeTests when both smokeTests and legacy wp are set', () => {
+      const config = createConfig({
+        tests: {
+          smokeTests: false,
+          wp: true, // This should be ignored when smokeTests is explicitly set
+        },
+      });
+      expect(() => selectTestFiles(config)).toThrow('No test files selected');
+    });
+
+    it('should use projectType over legacy tests.plugin', () => {
+      const config = createConfig({
+        projectType: 'theme', // This takes precedence
+        tests: {
+          smokeTests: true,
+          plugin: 'my-plugin', // Legacy, should be ignored for applicability
+        },
+      });
+      const files = selectTestFiles(config);
+      expect(files).toContain('src/smoke-tests/wp.spec.ts');
+      expect(files).toContain('src/smoke-tests/theme.spec.ts');
+      // Plugin tests should also run because tests.plugin is set (legacy fallback)
+      expect(files).toContain('src/smoke-tests/plugin.spec.ts');
+    });
+  });
+});
+
+describe('SMOKE_TEST_REGISTRY', () => {
+  it('should export a registry of known smoke tests', () => {
+    expect(SMOKE_TEST_REGISTRY).toBeDefined();
+    expect(typeof SMOKE_TEST_REGISTRY).toBe('object');
+  });
+
+  it('should contain expected WordPress tests', () => {
+    expect(SMOKE_TEST_REGISTRY.wpBoot).toBeDefined();
+    expect(SMOKE_TEST_REGISTRY.wpBoot.category).toBe('wp');
+    expect(SMOKE_TEST_REGISTRY.wpAdminLoads).toBeDefined();
+    expect(SMOKE_TEST_REGISTRY.wpRestApiAvailable).toBeDefined();
+  });
+
+  it('should contain expected plugin tests', () => {
+    expect(SMOKE_TEST_REGISTRY.pluginActivates).toBeDefined();
+    expect(SMOKE_TEST_REGISTRY.pluginActivates.category).toBe('plugin');
+    expect(SMOKE_TEST_REGISTRY.pluginDeactivates).toBeDefined();
+    expect(SMOKE_TEST_REGISTRY.pluginLoads).toBeDefined();
+  });
+
+  it('should contain expected theme tests', () => {
+    expect(SMOKE_TEST_REGISTRY.themeActivates).toBeDefined();
+    expect(SMOKE_TEST_REGISTRY.themeActivates.category).toBe('theme');
+    expect(SMOKE_TEST_REGISTRY.themeLoads).toBeDefined();
   });
 });

--- a/packages/test-fixtures/fixtures/wp-tester-plugin/wp-tester.json
+++ b/packages/test-fixtures/fixtures/wp-tester-plugin/wp-tester.json
@@ -16,13 +16,12 @@
     }
   ],
   "tests": {
-    "wp": true,
-    "plugin": "wp-tester-plugin",
     "phpunit": {
       "phpunitPath": "vendor/bin/phpunit",
       "configPath": "phpunit.xml.dist",
       "bootstrapPath": "tests/bootstrap.php",
       "testMode": "integration"
-    }
+    },
+    "smokeTests": true
   }
 }

--- a/packages/test-fixtures/fixtures/wp-tester-theme/wp-tester.json
+++ b/packages/test-fixtures/fixtures/wp-tester-theme/wp-tester.json
@@ -18,7 +18,7 @@
     }
   ],
   "tests": {
-    "theme": "wp-tester-theme",
+    "smokeTests": true,
     "phpunit": {
       "phpunitPath": "vendor/bin/phpunit",
       "configPath": "phpunit.xml.dist",


### PR DESCRIPTION
Refactors smoke test configuration to use a unified smokeTests option instead of separate wp, plugin, and theme test types to enable support for more smoke tests in the future. 

## Motivation for the change, related issues

The previous configuration model had several issues:
- CLI arguments (--test=wp, --test=plugin, --test=theme) duplicated information already
present in the config (projectType)
- Config had separate tests.wp, tests.plugin, and tests.theme properties that were
confusing to users
- Test selection logic was scattered and hard to maintain

The new model:
- Uses projectType to determine which smoke tests are applicable (plugin tests for
plugins, theme tests for themes)
- Provides a single tests.smokeTests option to enable/disable or filter tests
- Simplifies CLI to just --test=smoke or --test=phpunit

## Implementation details

### Config schema changes

New SmokeTests type:
type SmokeTests =
  | boolean  // true = run all applicable, false = disable
  | { include?: string[]; exclude?: string[] }  // filter specific tests

Deprecated properties (still work, with migration path):
- tests.wp → tests.smokeTests: true
- tests.plugin → projectType: "plugin" + tests.smokeTests: true
- tests.theme → projectType: "theme" + tests.smokeTests: true

### CLI changes

Before: --test=wp|plugin|theme|phpunit
After: --test=smoke|phpunit

The TestType union changed from "wp" | "plugin" | "theme" | "phpunit" to "smoke" |
"phpunit".

### Test selection logic

A new SMOKE_TEST_REGISTRY maps test names to categories and spec files:
- wp category: wpBoot, wpAdminLoads, wpRestApiAvailable (always run)
- plugin category: pluginActivates, pluginDeactivates, pluginLoads (run when projectType:
"plugin")
- theme category: themeActivates, themeLoads (run when projectType: "theme")

### Config migration command

Added wp-tester config migrate to automatically upgrade deprecated config formats:
wp-tester config migrate --config ./wp-tester.json

### Validation improvements

- Validates smokeTests.include/exclude against known test names
- Warns about unknown test names (for forward compatibility)
- Detects deprecated config properties and suggests migration

## Testing Instructions

Run the test suites:
`npm run test`

Verify CLI help shows new options:
`npm run cli -- test --help`

Test with a plugin config:
```
npm run cli -- test --config=./packages/test-fixtures/fixtures/wp-tester-plugin
npm run cli -- test --test=smoke --config=./packages/test-fixtures/fixtures/wp-tester-plugin
```

Test config migration:
`npm run cli -- config migrate --config=./path/to/old-config.json`